### PR TITLE
filetransfers

### DIFF
--- a/DataMovement/TransferringData/FileZilla.md
+++ b/DataMovement/TransferringData/FileZilla.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: FileZilla
+grand_parent: Data Movement
+parent: Transferring Data
+---
+# Transferring files using FileZilla
+
+*FileZilla can be used to securely transfer files between your local computer running Windows, Linux or MacOS to a remote computer running Linux.*
+
+### Setting Up FileZilla
+
+- Download and install [FileZilla](https://filezilla-project.org).
+
+### Connecting to a Host
+
+- Decide which host you wish to connect to such as, eagle.hpc.nrel.gov
+- Enter your username in the Username field.
+- Enter your password or Password+OTP Token in the Password field.
+- Use 22 as the Port.
+- Click the 'Quickconnect' button.
+
+### Transferring Files
+
+You may use FileZilla to transfer individual files or directories from the Local Directory to the Remote Directory or vice versa.
+
+Transfer files by dragging them from the Local Directory (left pane) to the Remote Directory (right pane) or vice versa.  Once the transfer is complete the selected file will be visible in the pane it was transferred to.

--- a/DataMovement/TransferringData/file-transfers.md
+++ b/DataMovement/TransferringData/file-transfers.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: File Transfers
-grand_parent: General
-parent: Beginner
+grand_parent: Data Movement
+parent: Transferring Data
 ---
 
 # Transferring files
@@ -18,7 +18,7 @@ The below command is used to check your quota from an Eagle login node.  `hours_
 $ hours_report
 ```
 
-## Best Practices for Transfering Files
+## Best Practices for Transferring Files
 
 #### File Transfers Between Filesystems on the NREL network
 
@@ -65,7 +65,7 @@ For Windows you will need to download WinSCP to transfer files to and from HPC s
 
 *Learn various techniques to combine and compress multiple files or directories into a single file to reduce storage footprint or simplify sharing.*
 
-## `tar`
+## tar
 
 `tar`, along with [`zip`](#zip), is one of the basic commands to combine multiple individual files into a single file (called a "tarball"). `tar` requires at least one command line option. A typical usage would be:
 ```bash

--- a/DataMovement/TransferringData/globus.md
+++ b/DataMovement/TransferringData/globus.md
@@ -1,0 +1,85 @@
+---
+layout: default
+title: Globus
+grand_parent: Data Movement
+parent: Transferring Data
+---
+# Transfering Files with Globus
+
+*For large data transfers between NREL’s high-performance computing (HPC) systems and another data center, or even a laptop off-site, we recommend using Globus.*
+
+A supported set of instructions for requesting a HPC Globus account and data transfer using Globus is available on the [HPC NREL Website](https://www.nrel.gov/hpc/globus-file-transfer.html)
+
+### What Is Globus?
+
+Globus provides services for research data management, including file transfer. It enables you to **quickly, securely and reliably move your data to and from locations you have access to**.
+
+Globus transfers files using **GridFTP**. GridFTP is a high-performance data transfer protocol which is optimized for high-bandwidth wide-area networks.  It provides more reliable high performance file transfer and synchronization than scp or rsync. It automatically tunes parameters to maximize bandwidth while providing automatic fault recovery and notification of completion or problems.
+
+### Globus Personal endpoints
+
+You can set up a "Globus Connect Personal EndPoint", which turns your personal computer into an endpoint, by downloading and installing the Globus Connect Personal application on your system. We use a personal endpoint to demonstrate how to transfer files to and from Peregrine.
+
+###### Set Up a Personal EndPoint
+
+- Login to the Globus website. From the Manage Data drop down menu, select Transfer Files. Then click Get Globus Connect Personal.
+- Pick a name for your personal endpoint and select Generate Startup Key. Follow the instructions on the web page to save your key.
+- Download and install the Globus Connect Personal software on your personal system.
+- Copy the startup key from the Globus web page to this application.
+
+###### Configure Permissions on a Personal EndPoint
+
+Once Globus Connect Personal is installed on your system, set up the permissions for reading or writing files to your local system.
+
+- If you are using a Mac, click on the "g" icon on the upper right portion of your screen to access the Globus Connect Personal application.
+- Select Preferences. To allow Globus to copy files to your local system, make sure that the directory (folder) they will go in is Writable.
+
+### Transferring Files
+
+You can transfer files with Globus through the [Globus Online](https://www.globus.org) website or via a CLI (command line interface).
+
+#### Globus Online
+
+Globus Online is a hosted service that allows you to use a browser to transfer files between trusted sites called "endpoints".  To use it, the Globus software must be installed on the systems at both ends of the data transfer. The NREL endpoint is nrel#globus.
+
+- Click Login on the [Globus web site](https://www.globus.org/). On the login page select "Globus ID" as the login method and click continue.  Use the Globus credentials you used to register your Globus.org account.
+- Go to the Transfer Files page, the link is located under the Manage Data tab at the top of the page.
+- Select **nrel#globus** as the endpoint on one right side. In the box asking for authentication, **enter your Peregrine (NREL HPC) username and password**. Do not use your globus.org username and password when authenticating with the nrel#globus endpoint.
+- Select another Globus endpoint, such as a personal endpoint or an endpoint at another institution that you have access to. To use your personal endpoint, first start the Globus Connect Personal application. Then enter "USERNAME#ENDPOINT" on the left side or use the drop down menu to find it. Click "go".
+- To transfer files
+  - Select the files you want to transfer someplace else from the system from the dialog box on the left.
+  - Select the destination location (a folder or directory) from the dialog box on right right.
+  - Click the large blue button at the top of the screen to begin to transfer the files.
+
+*When your transfer is complete, you will be notified by email.*
+
+#### Globus CLI (Command line Interface)
+
+Configuring your Globus.org account to allow ssh CLI access
+
+To use the CLI you must have a Globus account with ssh access enabled. To enable your account for ssh access you must add your ssh public key to your Globus account by visiting the [Manage Identities page](https://www.globus.org/account/ManageIdentities) and clicking "manage SSH and X.509 keys" and then "Add a New Key". If you do not have an ssh key, follow the [directions here](https://docs.globus.org/faq/command-line-interface/#how_do_i_generate_an_ssh_key_to_use_with_the_globus_command_line_interface) to create one.
+
+Globus.org CLI examples
+
+```shell
+$ ssh <globus username>@cli.globusonline.org <command>  <options> <params>
+$ ssh <globus username>@cli.globusonline.org help
+```
+
+A one-liner can be used to integrate globus.org CLI commands into shell scripts
+
+```shell
+$ ssh <globus username>@cli.globusonline.org scp nrel#globus:/globusro/file1.txt myuser#laptop:/tmp/myfile.txt
+```
+
+The globus.org CLI can be used interactively
+
+```shell
+$ ssh <globus username>@cli.globusonline.org
+Welcome to globusonline.org, <globus username>. Type 'help' for help.
+$ help
+$ scp nrel#globus:/globusro/file1.txt myuser#laptop:/tmp/myfile.txt
+$ exit
+```
+
+*You can find more information on the Globus CLI from the [official Globus CLI documentation](https://docs.globus.org/cli/examples/).*

--- a/DataMovement/TransferringData/transferringdata.md
+++ b/DataMovement/TransferringData/transferringdata.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Transferring Data
+has_children: true
+parent: Data Movement
+---

--- a/DataMovement/datamovement.md
+++ b/DataMovement/datamovement.md
@@ -1,0 +1,5 @@
+---
+layout: default
+title: Data Movement
+has_children: true
+---

--- a/General/beginner/file-transfers.md
+++ b/General/beginner/file-transfers.md
@@ -5,17 +5,17 @@ grand_parent: General
 parent: Beginner
 ---
 
-# how-to-transfer-files
+# Transferring files
 
 *Learn how to transfer data within, to and from NREL's high-performance computing (HPC) systems.*
 
 A supported set of instructions for data transfer using NREL HPC systems is provided on the [HPC NREL Website](https://www.nrel.gov/hpc/data-storage-transfer.html).
 
 ## Checking Usage and Quota
-The below command is used to check your quota from a Peregrine login node.  alloc_tracker will display your usage and quota for each filesystem.
+The below command is used to check your quota from an Eagle login node.  `hours_report` will display your usage and quota for each filesystem.
 
 ```bash
-$ alloc_tracker
+$ hours_report
 ```
 
 ## Best Practices for Transfering Files
@@ -28,7 +28,7 @@ rsync is the recommended tool for transferring data between NREL systems. It all
 $ rsync -aP --no-g /scratch/username/dataset1/ /mss/users/username/dataset1/
 ```
 
-*Mass Storage has quotas that limit the number of individual files you can store. If you are copying hundreds of thousands of files then it is best to archive these files prior to copying to Mass Storage. See the [guide on how to archive files](../intro-to-linux/archiving.md).*
+*Mass Storage has quotas that limit the number of individual files you can store. If you are copying hundreds of thousands of files then it is best to archive these files prior to copying to Mass Storage. See the [guide on how to archive files](#archiving-files-and-directories).*
 
 *Mass Storage quotas rely on the group of the file and not the directory path. It is best to use the `--no-g` option when rsyncing to MSS so you use the destination group rather than the group permissions of your source.  You can also `chgrp` your files to the appropriate group prior to rsyncing to MSS.*
 
@@ -58,4 +58,44 @@ $ wget https://URL
 Globus is optimized for file transfers between data centers and anything outside of the NREL network. It will be several times faster than any other tools you will have available. Documentation about requesting a HPC Globus account is available on the [Globus Services page on the HPC website](https://www.nrel.gov/hpc/globus-file-transfer.html).  See [Transfering files using Globus](globus.md) for instructions on transfering files with Globus.
 
 #### Transfering files using Windows
-For Windows you will need to download WinSCP to transfer files to and from HPC systems over SCP. See [Transfering using WinSCP](winscp.md).
+For Windows you will need to download WinSCP to transfer files to and from HPC systems over SCP. See [Transfering using WinSCP](https://www.nrel.gov/hpc/winscp-file-transfer.html).
+
+
+# Archiving files and directories
+
+*Learn various techniques to combine and compress multiple files or directories into a single file to reduce storage footprint or simplify sharing.*
+
+## *This is a temporary file to provide verbosity, edit/remove it or its content as needed.*
+
+## `tar`
+
+`tar`, along with [`zip`](#zip), is one of the basic commands to combine multiple individual files into a single file (called a "tarball"). `tar` requires at least one command line option. A typical usage would be:
+```bash
+$ tar -cf newArchiveName.tar file1 file2 file3
+# or
+$ tar -cf newArchiveName.tar /path/to/folder/
+```
+
+The `-c` flag denotes **c**reating an archive, and `-f` denotes that the next argument given will be the archive name&mdash;in this case it means the name you would prefer for the resulting archive file. 
+
+To extract files from a tar, it's recommended to use:
+```bash
+$ tar -xvf existingArchiveName.tar
+```
+`-x` is for **ex**tracting, `-v` uses **v**erbose mode which will print the name of each file as it is extracted from the archive.
+
+### Compressing
+
+`tar` can also generate compressed tarballs which reduce the size of the resulting archive. This can be done with the `-z` flag (which just calls [`gzip`](#gzip) on the resulting archive automatically, resulting in a `.tar.gz` extension) or `-j` (which uses [`bzip2`](#bzip2), creating a `.tar.bz2`).
+
+For example:
+
+```bash
+# gzip
+$ tar -czvf newArchive.tar.gz file1 file2 file3
+$ tar -xvzf newArchive.tar.gz
+
+# bzip2
+$ tar -czjf newArchive.tar.bz2 file1 file2 file3
+$ tar -xvjf newArchive.tar.bz2
+```

--- a/General/beginner/file-transfers.md
+++ b/General/beginner/file-transfers.md
@@ -65,8 +65,6 @@ For Windows you will need to download WinSCP to transfer files to and from HPC s
 
 *Learn various techniques to combine and compress multiple files or directories into a single file to reduce storage footprint or simplify sharing.*
 
-## *This is a temporary file to provide verbosity, edit/remove it or its content as needed.*
-
 ## `tar`
 
 `tar`, along with [`zip`](#zip), is one of the basic commands to combine multiple individual files into a single file (called a "tarball"). `tar` requires at least one command line option. A typical usage would be:


### PR DESCRIPTION
Draft update for the filetransfers docs. Updated Peregrine -> Eagle and alloc -> hours_report.

**Outstanding work**
- [x] References the archiving doc at `../intro-to-linux/archiving.md` in the master repo which is not currently present in the gh-pages-dev branch. This would be useful to update an include. 
- [x] Add additional transfer tool as suggested in #18 