### PR TITLE
Jupyter reorg

### DIFF
--- a/Jupyter/jupyter.md
+++ b/Jupyter/jupyter.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Jupyter
+has_children: true
+---
+
+# Jupyter notebooks and JupyterHub

--- a/Jupyter/jupyterhub.md
+++ b/Jupyter/jupyterhub.md
@@ -1,8 +1,7 @@
 ---
 layout: default
 title: JupyterHub
-grand_parent: General
-parent: Intermediate
+parent: Jupyter
 ---
 
 # JupyterHub
@@ -40,3 +39,7 @@ be able to access all Python modules therein.
 ## Using Jupyterhub from Eagle
 
 To use inside Eagle, the Jupyterhub server exists on the internal network @ https://europa-int/.
+
+## Customizing 
+
+JupyterHub provides the ability to use custom kernels including ones for other popular programming languages such as Julia and R. [NREL's custom kernels documentation](https://www.nrel.gov/hpc/jupyterhub.html) provides more information on how to setup JupyterHub with other languages. 


### PR DESCRIPTION
Moving Jupyter to a top level category. Also added a link to the JupyterHub doc on NREL's site. 