### PR TITLE
Adding scripts for launching jupyter lab via slurm

### DIFF
--- a/languages/python/jupyter/README.md
+++ b/languages/python/jupyter/README.md
@@ -1,0 +1,46 @@
+# jupyter lab
+
+Tools for working with jupyter lab on eagle
+
+There are a couple of bash scripts that can be used for launching a jupyter lab instance on an eagle compute node and then connecting via your local web browser.
+
+One example workflow is to use the `sbatch_jupyter.sh`, `auto_launch_jupyter.sh` scripts.
+
+Create your conda environment:
+```bash
+conda create -n jupyterenv python=3.8 jupyterlab
+```
+
+Update the `sbatch_jupyter.sh` script with your account information and desired run time:
+
+```bash
+#!/bin/bash  --login
+
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+#SBATCH --partition=short
+#SBATCH --tasks-per-node=1
+#SBATCH --cpus-per-task=36
+#SBATCH --account=<your-account-handle>
+```
+
+Then, you can submit and monitor the job automatically with:
+
+```bash
+bash auto_launch_jupyter.sh
+```
+
+This will submit the `sbatch_jupyter.sh` script to eagle and then monitor the status, eventually providing you will the commands you need to connect. The output should look something like:
+
+```
+[<hpc-username>@el2 bash]$ bash auto_launch_jupyter.sh
+Checking job status..
+job still pending..
+job is running!
+getting jupyter information, hang tight..
+okay, now run the follwing on your local machine:
+ssh -L 7878:r1i6n1:7878 el2.hpc.nrel.gov
+then, navigate to the following on your local browser:
+http://127.0.0.1:7878/?token=ed23bab2d938f52122c8cccf833dbee185d62adbfe56d02b
+```
+

--- a/languages/python/jupyter/auto_launch_jupyter.sh
+++ b/languages/python/jupyter/auto_launch_jupyter.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# exit when a bash command fails
+set -e
+
+unset XDF_RUNTIME_DIR
+
+RES=$(sbatch sbatch_jupyter.sh)
+
+jobid=${RES##* }
+
+tries=1
+wait=1
+echo "Checking job status.."
+while :
+do
+        status=$(scontrol show job $jobid | grep JobState | awk '{print $1}' | awk -F= '{print $2}')
+        if [ $status == "RUNNING" ]
+        then
+                echo "job is running!"
+                echo "getting jupyter information, hang tight.."
+                while :
+                do
+                        if [ ! -f slurm-$jobid.out ]
+                        then
+                                echo "waiting for slurm output to be written"
+                                let "wait+=1"
+                                sleep 1s
+                        elif [ $wait -gt 120 ]
+                        then
+                                echo "timed out waiting for output from job."
+                                echo "check to make sure job didn't fail"
+                                exit 0
+                        else
+                                check=$(cat slurm-$jobid.out | grep http://127.0.0.1 | wc -l)
+                                if [ $check -gt 0 ]
+                                then
+                                        echo "okay, now run the follwing on your local machine:"
+                                        echo $(cat slurm-$jobid.out | grep ssh)
+                                        echo "then, navigate to the following on your local browser:"
+                                        echo $(cat slurm-$jobid.out | grep http://127.0.0.1 | head -1 | awk {'print $5'})
+                                        exit 0
+                                else
+                                        let "wait+=1"
+                                        sleep 1s
+                                fi
+                        fi
+                done
+                exit 0
+        elif [ $tries -gt 120 ]
+        then
+                echo "timeout.. terminating job."
+                scancel $jobid
+                exit 0
+        else
+                echo "job still pending.."
+                sleep 10s
+        fi
+        ((tries++))
+done

--- a/languages/python/jupyter/create_env.sh
+++ b/languages/python/jupyter/create_env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+module load conda
+conda create -y -c conda-forge -n jupyterlab python=3.8 pandas scipy numpy matplotlib seaborn jupyterlab  

--- a/languages/python/jupyter/create_env.sh
+++ b/languages/python/jupyter/create_env.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 module load conda
-conda create -y -c conda-forge -n jupyterlab python=3.8 pandas scipy numpy matplotlib seaborn jupyterlab  
+conda create -y -c conda-forge -n jupyterenv python=3.8 pandas scipy numpy matplotlib seaborn jupyterlab  

--- a/languages/python/jupyter/sbatch_jupyter.sh
+++ b/languages/python/jupyter/sbatch_jupyter.sh
@@ -5,11 +5,11 @@
 #SBATCH --partition=short
 #SBATCH --tasks-per-node=1
 #SBATCH --cpus-per-task=36
-#SBATCH --account=mbap
+#SBATCH --account=<account-handle>
 
 module purge
 module load conda
-conda activate /home/$USER/.conda/envs/dask
+conda activate /home/$USER/.conda/envs/jupyterenv
 
 port=7878
 

--- a/languages/python/jupyter/sbatch_jupyter.sh
+++ b/languages/python/jupyter/sbatch_jupyter.sh
@@ -1,0 +1,20 @@
+#!/bin/bash  --login
+
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+#SBATCH --partition=short
+#SBATCH --tasks-per-node=1
+#SBATCH --cpus-per-task=36
+#SBATCH --account=mbap
+
+module purge
+module load conda
+conda activate /home/$USER/.conda/envs/dask
+
+port=7878
+
+echo "run the following command on your machine"
+echo ""
+echo "ssh -L $port:$HOSTNAME:$port $SLURM_SUBMIT_HOST.hpc.nrel.gov"
+
+jupyter lab --no-browser --ip=0.0.0.0 --port=$port

--- a/languages/python/jupyter/sbatch_jupyter.sh
+++ b/languages/python/jupyter/sbatch_jupyter.sh
@@ -9,7 +9,7 @@
 
 module purge
 module load conda
-conda activate /home/$USER/.conda/envs/jupyterenv
+source activate /home/$USER/.conda/envs/jupyterenv
 
 port=7878
 


### PR DESCRIPTION
This PR adds a couple of scripts and documentation for automating the process of launching a jupyter lab instance on an eagle compute node.

The `auto_launch_jupyter.sh` script is a bit of a beast but we've used it with success in the Transportation (5400/MBAP) group. Maybe someone with bash expertise could review to see if there are any gaping holes.

I reviewed the contributing guidelines but this is my first PR in this repository so I apologize if I missed anything!