### PR TITLE
New docs landing pae

### DIFF
--- a/docs/Documentation/index.md
+++ b/docs/Documentation/index.md
@@ -1,0 +1,24 @@
+---
+layout: main
+title: Documentation Home
+nav_order: 1
+description: Documentation Home
+
+---
+
+Welcome to the central source of user-contributed documentation for Eagle and other NREL HPC systems. This repository is open to both NREL and non-NREL HPC users. You can browse the documentation here, or start contributing by [visiting the repository in Git](https://github.com/NREL/HPC) for more information.
+
+## Where to Begin
+
+Please use the navigation bar on the left to explore the available documentation by category.
+
+### Highlights 
+* [Systems Guide](https://nrel.github.io/HPC/Documentation/Systems/) to learn about our HPC systems
+* [Jupyterhub](Documentation/Jupyter/jupyterhub/) to get started with Jupyter Notebooks 
+* [Conda environment](Documentation/Environments/conda/) howto and Eagle-specific information
+
+### Other NREL Documentation Resources
+
+* The [NREL HPC Website](https://hpc.nrel.gov) is the home of Advanced Computing at NREL
+* Our [Github Repository](https://github.com/NREL/HPC) for specific application examples, scripts, workshop content, the contributor guide, and more. 
+* The [gh-pages branch](https://github.com/NREL/HPC/tree/gh-pages) (this site) is also open for contribution.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Dev
 
-## Running locally
-The easiest way to run this GH Pages locally is using Docker. The following command will install the necessary Ruby Gems and build the site. The site will be available at `localhost:4000/HPC/`
+# Development
+
+The following Docker command can be run to build a local version of the docs for development. The site will be available at localhost:8000 in your browser.
 
 ```
-docker run -it -p 4000:4000 -v "$PWD:/srv/jekyll" jekyll/builder ./build_and_serve.sh 
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hide:
 ## Intro
 A collection of various resources, examples, and executables for the general NREL HPC user community's benefit.
 
-[Documentation](Documentation/Data-and-File-Systems/File-Systems/index.md){ .md-button }
+[Documentation](Documentation/index.md){ .md-button }
 
 ## Contributing 
 These docs are driven by the NREL HPC community. They are currently under active development. If you would like to [contribute](https://github.com/NREL/HPC/blob/dev/CONTRIBUTING.md) or recommend a topic to be covered please open an issue or pull request in the repository. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,8 @@ nav:
       - blog/2020-12-01-numba.md
       - blog/2021-05-06-tf.md
       - blog/2021-06-18-srun.md
-  - Documentation:
+  - Documentation Home:
+      - Documentation Home: Documentation/index.md
       - Data and File Systems:
         - File Systems:
           - Documentation/Data-and-File-Systems/File-Systems/index.md 


### PR DESCRIPTION
Adds new home/landing page for Documentation. Also fixes an errant docs/README.md file to have the most current docker+mkdocs instructions.