### PR TITLE
Remove references to Peregrine and update documentation with Eagle content

### DIFF
--- a/applications/gaussian/large/cpu1/g16.slurm
+++ b/applications/gaussian/large/cpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=l.cpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/large/cpu2/g16.slurm
+++ b/applications/gaussian/large/cpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=l.cpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/large/gpu1/g16.slurm
+++ b/applications/gaussian/large/gpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=l.gpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup)
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/large/gpu2/g16.slurm
+++ b/applications/gaussian/large/gpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=l.gpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup)
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/medium/cpu1/g16.slurm
+++ b/applications/gaussian/medium/cpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=m.cpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/medium/cpu2/g16.slurm
+++ b/applications/gaussian/medium/cpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=m.cpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/medium/gpu1/g16.slurm
+++ b/applications/gaussian/medium/gpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=m.gpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/medium/gpu2/g16.slurm
+++ b/applications/gaussian/medium/gpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=m.gpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/small/cpu1/g16.slurm
+++ b/applications/gaussian/small/cpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=s.cpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/small/cpu2/g16.slurm
+++ b/applications/gaussian/small/cpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=s.cpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/small/gpu1/g16.slurm
+++ b/applications/gaussian/small/gpu1/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=1
 #SBATCH --job-name=s.gpu1
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/applications/gaussian/small/gpu2/g16.slurm
+++ b/applications/gaussian/small/gpu2/g16.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=4:00:00             
+#SBATCH --time=4:00:00
 #SBATCH --nodes=2
 #SBATCH --job-name=s.gpu2
 #SBATCH --output=std.out
@@ -19,53 +19,52 @@ cd $SLURM_SUBMIT_DIR
 INPUT_BASENAME=G16_test
 INPUT_FILE=$INPUT_BASENAME.com
 GAUSSIAN_EXEC=g16
-MEMSIZE=5GB 
+MEMSIZE=5GB
 SCRATCH=/tmp/scratch/$SLURM_JOB_ID
-SCRATCH2=/dev/shm 
-# 
-# Check on editing input file. If scratch directories 
-# are listed then file is used un-changed, if 3-line 
-# header not present, then script prepends these lines 
-# to the input file to be used in execution line 
-# 
-NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l` 
-if [ $NUMRWFLINES -eq 1 ]; then 
- echo "standard file found" 
- cp $INPUT_FILE infile 
-else 
- echo "prepending lines to input file" 
- echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile 
- echo "%NoSave" >> infile 
- echo " " >> infile 
- cat $INPUT_FILE >> infile 
-fi 
+SCRATCH2=/dev/shm
+#
+# Check on editing input file. If scratch directories
+# are listed then file is used un-changed, if 3-line
+# header not present, then script prepends these lines
+# to the input file to be used in execution line
+#
+NUMRWFLINES=`grep "RWF" $INPUT_FILE | wc -l`
+if [ $NUMRWFLINES -eq 1 ]; then
+ echo "standard file found"
+ cp $INPUT_FILE infile
+else
+ echo "prepending lines to input file"
+ echo "%RWF=$SCRATCH2/,$MEMSIZE,$SCRATCH/,-1" > infile
+ echo "%NoSave" >> infile
+ echo " " >> infile
+ cat $INPUT_FILE >> infile
+fi
 
-# 
-# Run gaussian Peregrine script (performs much of the Gaussian setup) 
-g16_eagle 
+#
+# Run gaussian Eagle script (performs much of the Gaussian setup) 
+g16_eagle
 
-# 
-# Set required Gaussian environment variables 
-# 
-if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then 
- export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"' 
- export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR 
-fi 
-export GAUSS_SCRDIR=$SCRATCH2 
-# 
-# Gaussian needs scratch directories 
-# Note: sometimes files may have been left behind in 
-# on-node memory by other jobs that terminated incorrectly 
-# so clean these to make sure there is enough space. 
-# 
- 
-mkdir $SCRATCH 
-rm -rf $SCRATCH2/* 
+#
+# Set required Gaussian environment variables
+#
+if [ $SLURM_JOB_NUM_NODES -gt 1 ]; then
+ export GAUSS_LFLAGS='-vv -opt "Tsnet.Node.lindarsharg: ssh"'
+ export GAUSS_EXEDIR=$g16root/g16/linda-exe:$GAUSS_EXEDIR
+fi
+export GAUSS_SCRDIR=$SCRATCH2
+#
+# Gaussian needs scratch directories
+# Note: sometimes files may have been left behind in
+# on-node memory by other jobs that terminated incorrectly
+# so clean these to make sure there is enough space.
+#
 
-# Run Gaussian job 
-$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log 
+mkdir $SCRATCH
+rm -rf $SCRATCH2/*
+
+# Run Gaussian job
+$GAUSSIAN_EXEC < infile >& $INPUT_BASENAME.log
 rm infile
 
 rm $SCRATCH/*
 rmdir $SCRATCH
-

--- a/general/beginner/how-to-transfer-files/README.md
+++ b/general/beginner/how-to-transfer-files/README.md
@@ -5,7 +5,7 @@
 A supported set of instructions for data transfer using NREL HPC systems is provided on the [HPC NREL Website](https://www.nrel.gov/hpc/data-storage-transfer.html).
 
 ## Checking Usage and Quota
-The below command is used to check your quota from a Peregrine login node.  alloc_tracker will display your usage and quota for each filesystem.
+The below command is used to check your quota from a Eagle login node.  alloc_tracker will display your usage and quota for each filesystem.
 
 ```bash
 $ alloc_tracker

--- a/general/beginner/how-to-transfer-files/globus.md
+++ b/general/beginner/how-to-transfer-files/globus.md
@@ -12,7 +12,7 @@ Globus transfers files using **GridFTP**. GridFTP is a high-performance data tra
 
 ### Globus Personal endpoints
 
-You can set up a "Globus Connect Personal EndPoint", which turns your personal computer into an endpoint, by downloading and installing the Globus Connect Personal application on your system. We use a personal endpoint to demonstrate how to transfer files to and from Peregrine.
+You can set up a "Globus Connect Personal EndPoint", which turns your personal computer into an endpoint, by downloading and installing the Globus Connect Personal application on your system. We use a personal endpoint to demonstrate how to transfer files to and from Eagle.
 
 ###### Set Up a Personal EndPoint
 
@@ -38,7 +38,7 @@ Globus Online is a hosted service that allows you to use a browser to transfer f
 
 - Click Login on the [Globus web site](https://www.globus.org/). On the login page select "Globus ID" as the login method and click continue.  Use the Globus credentials you used to register your Globus.org account.
 - Go to the Transfer Files page, the link is located under the Manage Data tab at the top of the page.
-- Select **nrel#globus** as the endpoint on one right side. In the box asking for authentication, **enter your Peregrine (NREL HPC) username and password**. Do not use your globus.org username and password when authenticating with the nrel#globus endpoint.
+- Select **nrel#globus** as the endpoint on one right side. In the box asking for authentication, **enter your Eagle (NREL HPC) username and password**. Do not use your globus.org username and password when authenticating with the nrel#globus endpoint.
 - Select another Globus endpoint, such as a personal endpoint or an endpoint at another institution that you have access to. To use your personal endpoint, first start the Globus Connect Personal application. Then enter "USERNAME#ENDPOINT" on the left side or use the drop down menu to find it. Click "go".
 - To transfer files
   - Select the files you want to transfer someplace else from the system from the dialog box on the left.

--- a/general/beginner/how-to-transfer-files/winscp.md
+++ b/general/beginner/how-to-transfer-files/winscp.md
@@ -10,7 +10,7 @@
 
 ### Connecting to a Host
 
-- Set up a host (if needed) by selecting "New Site" and providing a host name (e.g. peregrine.nrel.gov) and your user name.  In most cases, use the SFTP protocol.
+- Set up a host (if needed) by selecting "New Site" and providing a host name (e.g. eagle.hpc.nrel.gov) and your user name.  In most cases, use the SFTP protocol.
 - Connect to the server by selecting a site and clicking [Login].
 - Enter your password or Password+OTP Token when prompted.
 

--- a/general/beginner/markdown/RenameStep2.md
+++ b/general/beginner/markdown/RenameStep2.md
@@ -7,12 +7,10 @@
 
 1. Obtain an account on NREL HPC
 2. Install X and Y locally.
-3. Prepare the Z environment on Peregrine
-   a. Login to Peregrine  
+3. Prepare the Z environment on Eagle
+   a. Login to Eagle  
    b. View software and get access to a compute node  
-   c. First-time setup for Z on Peregrine  
+   c. First-time setup for Z on Eagle  
 4. Run example 1.
 5. Run example 2.
 6. Visualize examples 1 and 2.
-
-

--- a/general/intermediate/software-environment-basics/README.md
+++ b/general/intermediate/software-environment-basics/README.md
@@ -1,6 +1,6 @@
 # software-environment-basics
 
-Peregine uses [environment modules](http://modules.sourceforge.net/) to enable use of multiple software packages. There is a [detailed guide](https://www.nrel.gov/hpc/eagle-environment-modules.html) to finding and using modules.  The following guides show how to utilize the more complex modules:
+Eagle uses [environment modules](http://modules.sourceforge.net/) to enable use of multiple software packages. There is a [detailed guide](https://www.nrel.gov/hpc/eagle-environment-modules.html) to finding and using modules.  The following guides show how to utilize the more complex modules:
 
 1) [Anaconda](conda-how-to.md)
 

--- a/general/intermediate/software-environment-basics/singularity-how-to.md
+++ b/general/intermediate/software-environment-basics/singularity-how-to.md
@@ -3,13 +3,13 @@ Singularity is installed on CentOS 7 compute nodes as a module named singularity
 
 ### Run hello-world ubuntu image
 
-1. Log into compute node, checking it is running CentOS 7 
+1. Log into compute node, checking it is running CentOS 7
 
 ```
 $ ssh el1.hpc.nrel.gov
 [$USER@el1 ~]$ salloc -A MYALLOCATION -t 60 -N 1
-[$USER@r1i3n18 ~]$ cat /etc/redhat-release 
-CentOS Linux release 7.4.1708 (Core) 
+[$USER@r1i3n18 ~]$ cat /etc/redhat-release
+CentOS Linux release 7.4.1708 (Core)
 
 ```
 
@@ -27,7 +27,7 @@ CentOS Linux release 7.4.1708 (Core)
 [$USER@r1i3n18 $USER]$ mkdir -p singularity-images
 [$USER@r1i3n18 $USER]$ cd singularity-images
 [$USER@r1i3n18 singularity-images]$ singularity pull --name hello-world.simg shub://vsoch/hello-world
-Progress |===================================| 100.0% 
+Progress |===================================| 100.0%
 Done. Container is at: /lustre/eaglefs/scratch/$USER/singularity-images/hello-world.simg
 ```
 
@@ -47,7 +47,7 @@ Done. Container is at: /lustre/eaglefs/scratch/$USER/singularity-images/hello-wo
     "org.label-schema.build-size": "333MB"
 }
 [$USER@r1i3n18 singularity-images]$ singularity inspect -r hello-world.simg # Shows the script run
-#!/bin/sh 
+#!/bin/sh
 
 exec /bin/bash /rawr.sh
 ```
@@ -62,33 +62,33 @@ RaawwWWWWWRRRR!!
 6. Run in singularity bash shell
 
 ```
-[$USER@r1i3n18 singularity-images]$ cat /etc/redhat-release 
-CentOS Linux release 7.4.1708 (Core) 
-[$USER@r1i3n18 singularity-images]$ cat /etc/lsb-release 
+[$USER@r1i3n18 singularity-images]$ cat /etc/redhat-release
+CentOS Linux release 7.4.1708 (Core)
+[$USER@r1i3n18 singularity-images]$ cat /etc/lsb-release
 cat: /etc/lsb-release: No such file or directory
 [$USER@r1i3n18 singularity-images]$ singularity shell hello-world.simg
 Singularity: Invoking an interactive shell within container...
 
-Singularity hello-world.simg:~> cat /etc/lsb-release 
+Singularity hello-world.simg:~> cat /etc/lsb-release
 DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=14.04
 DISTRIB_CODENAME=trusty
 DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
-Singularity hello-world.simg:~> cat /etc/redhat-release 
+Singularity hello-world.simg:~> cat /etc/redhat-release
 cat: /etc/redhat-release: No such file or directory
 ```
 
-## How to use singularity on peregrine
-Singularity is installed on CentOS 7 compute nodes as a module named singularity-container.  Images can be copied to peregrine to run or can be generated from a [recipe](http://singularity.lbl.gov/docs-recipes).  In the examples below, output is only shown for test and run blocks.  Input commands are preceded by a `$`
+## How to use singularity on Eagle
+Singularity is installed on CentOS 7 compute nodes as a module named singularity-container.  Images can be copied to Eagle to run or can be generated from a [recipe](http://singularity.lbl.gov/docs-recipes).  In the examples below, output is only shown for test and run blocks.  Input commands are preceded by a `$`
 
 ### Run hello-world ubuntu image
 
-1. Log into compute node, checking it is running CentOS 7 
+1. Log into compute node, checking it is running CentOS 7
 
 ```
 ssh peregrine-login4.hpc.nrel.gov
 qsub -I -A MYALLOCATION -q debug -l nodes=1,walltime=01:00:00
-cat /etc/redhat-release 
+cat /etc/redhat-release
 ```
 
 2. Load the singularity-container module
@@ -125,7 +125,7 @@ $ singularity inspect hello-world.simg
 }
 # Shows the script run
 $ singularity inspect -r hello-world.simg
-#!/bin/sh 
+#!/bin/sh
 
 exec /bin/bash /rawr.sh
 ```
@@ -141,27 +141,27 @@ RaawwWWWWWRRRR!!
 
 ```
 # On compute node
-$ cat /etc/redhat-release 
-CentOS Linux release 7.3.1611 (Core) 
-$ cat /etc/lsb-release 
+$ cat /etc/redhat-release
+CentOS Linux release 7.3.1611 (Core)
+$ cat /etc/lsb-release
 cat: /etc/lsb-release: No such file or directory
 # In singularity shell
 $ singularity shell hello-world.simg
 Singularity: Invoking an interactive shell within container...
 
-Singularity hello-world.simg:~> cat /etc/lsb-release 
+Singularity hello-world.simg:~> cat /etc/lsb-release
 DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=14.04
 DISTRIB_CODENAME=trusty
 DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
-Singularity hello-world.simg:~> cat /etc/redhat-release 
+Singularity hello-world.simg:~> cat /etc/redhat-release
 cat: /etc/redhat-release: No such file or directory
 ```
 
 
 ### Create a CentOS 7 EPEL image with MPI support
 
-This example shows how to create a CentOS 7 singularity image with openmpi installed.  It requires root/admin privileges to create the image so must be run on a user's computer with singularity installed.  After creation, the image can be copied to peregrine and run.
+This example shows how to create a CentOS 7 singularity image with openmpi installed.  It requires root/admin privileges to create the image so must be run on a user's computer with singularity installed.  After creation, the image can be copied to Eagle and run.
 
 1. Create a new recipe based on singularityhub/centos:latest
 

--- a/languages/c/README.md
+++ b/languages/c/README.md
@@ -3,18 +3,18 @@
     Wiki](NREL-HPC-User-Community-Wiki_15171667.html)
 3.  [Tips and Tricks](Tips-and-Tricks_18593769.html)
 
- HPC User Wiki : C Programs 
+ HPC User Wiki : C Programs
 ===========================
 
 Created by Southerland, Jennifer on 2018-01-23
 
-Compiling and Running C Programs on the Peregrine System
+Compiling and Running C Programs on the Eagle System
 ========================================================
 
 ### Simple "Hello, world" Program
 
 Follow these instructions to compile and run your first programs written
-in C on Peregrine.
+in C on Eagle.
 
 Copy this text to a file named hello\_world.c with your favorite text
 editor (nano, vi, emacs, etc.).
@@ -89,9 +89,9 @@ editor (vi, emacs, etc.)  If you are not familiar with text editors, try
        MPI_Init (&argc, &argv); /* starts MPI */
        MPI_Comm_rank (MPI_COMM_WORLD, &rank);     /* get current process id */
        MPI_Comm_size (MPI_COMM_WORLD, &size);     /* get number of processes */
-     
+
         printf( "Hello, world from process %d of %d\n", rank, size );
-     
+
         MPI_Finalize();
        return 0;
     }
@@ -105,7 +105,7 @@ The compiler will create a linux executable file called hello\_world.
 
 ### Running your Parallel “Hello, world” program
 
-Peregrine is a cluster: a collection of computers connected together
+Eagle is a cluster: a collection of computers connected together
 with a special network (InfiniBand in this case) and software (Torque)
 that allows a single program to run across multiple physical computers.
 Create a submit script which contains options for torque, including the

--- a/languages/fortran/README.md
+++ b/languages/fortran/README.md
@@ -4,16 +4,16 @@
 3.  [Tips and Tricks](Tips-and-Tricks_18593769.html)
 4.  [Fortran 90](Fortran90/f90.md)
 
- HPC User Wiki : Fortran Programs 
+ HPC User Wiki : Fortran Programs
 =================================
 
 Created by Southerland, Jennifer, last modified on 2018-01-23
 
-Compiling and Running Fortran Programs on the Peregrine System
+Compiling and Running Fortran Programs on the Eagle System
 ==============================================================
 
 Follow these instructions to compile and run your Fortran program on
-Peregrine.
+Eagle.
 
 Create Program
 --------------
@@ -23,7 +23,7 @@ hello.F90.
 
 If you don't already know how to use a text editor, we suggest you learn
 to use nano. To create the file named hello.F90, enter the following
-command on the login node on Peregrine:
+command on the login node on Eagle:
 
     $ nano hello.F90
 
@@ -48,7 +48,7 @@ Compile Program
 
 To convert your program from a human-readable language like Fortran
 (which is used in the example above) to the language used inside the
-computer, a program called a "compiler" is used. Peregrine has several
+computer, a program called a "compiler" is used. Eagle has several
 different compilers for each commonly used language. For this example,
 we will use the compilers that are developed by Intel. The command used
 to run the Intel Fortran compiler is "ifort". To run it on the file you


### PR DESCRIPTION
Replaced references to "Peregrine" with "Eagle". However, there are a few files with outdated instructions where "peregrine" is referenced in code. Replacing these will require updating those instructions as well.