### PR TITLE
Swift filesystems

### DIFF
--- a/docs/Documentation/Systems/Swift/filesystems.md
+++ b/docs/Documentation/Systems/Swift/filesystems.md
@@ -34,7 +34,7 @@ Project directories are automatically mounted or unmounted via NFS on an "as-nee
 
 For users who also have Eagle allocations, please be aware that scratch space on Swift behaves differently, so adjustments to job scripts may be necessary. 
 
-The scratch directory on each Swift compute node is a 1.8TB spinning disk, and is accessible only on that node. The default writable path for scratch use is `/scratch/<username>`. There is no global, network-accessible `/scratch` space. `/projects` and `/home` are 
+The scratch directory on each Swift compute node is a 1.8TB spinning disk, and is accessible only on that node. The default writable path for scratch use is `/scratch/<username>`. There is no global, network-accessible `/scratch` space. `/projects` and `/home` are both network-accessible, and may be used as /scratch-style working space instead.
 
 
 ## Temporary space: $TMPDIR 

--- a/docs/Documentation/Systems/Swift/filesystems.md
+++ b/docs/Documentation/Systems/Swift/filesystems.md
@@ -39,7 +39,7 @@ The scratch directory on each Swift compute node is a 1.8TB spinning disk, and i
 
 ## Temporary space: $TMPDIR 
 
-When a job starts, the environment variable `$TMPDIR` is set to `/scratch/<username>/<jobid>` for the duration of the job. This is temporary space only, and should be purged when your job is complete. 
+When a job starts, the environment variable `$TMPDIR` is set to `/scratch/<username>/<jobid>` for the duration of the job. This is temporary space only, and should be purged when your job is complete. Please be sure to use this path instead of /tmp for your tempfiles.
 
 There is no expectation of data longevity in scratch space, and it is subject to purging once the node is idle. If desired data is stored here during the job, please be sure to copy it to a /projects directory as part of the job script before the job finishes.
 

--- a/docs/Documentation/Systems/Swift/filesystems.md
+++ b/docs/Documentation/Systems/Swift/filesystems.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Filesystems
+parent: Systems
+has_children: true
+---
+
+
+
+# Filesystems on Swift
+
+Swift's central storage consists of approximately 3PB of NFS-mounted storage, served over NFS (Network File System). The underlying filesystem management is via ZFS. 
+
+Unlike the Lustre-based storage on Eagle, Swift currently does not host a parallel file system.
+
+## Project Storage: /projects
+
+Each active project is granted a subdirectory under `/projects/<projectname>`. This is where the bulk of data is expected to be, and where jobs should generally be run from. Storage quotas are based on the allocation award.
+
+Quota usage can be viewed at any time by issuing a `cd` command into the project directory, and using the `df -h` command to view total, used, and remaining available space for the mounted project directory.
+
+### NFS Automount System
+
+Project directories are automatically mounted or unmounted via NFS on an "as-needed" basis. /projects directories that have not been accessed for a period of time will be umounted and not immediately visible via a command such as `ls /projects`, but will become immediately available if a file or path is accessed with an `ls`, `cd`, or other file access is made in that path. 
+
+## Home Directories: /home
+
+/home directories are mounted as `/home/<username>`. Home directories are hosted under the user's initial /project directory. Quotas in /home are included as a part of the quota of that project's storage allocation. 
+
+## Scratch Space: /scratch/username and /scratch/username/jobid
+
+For users who also have Eagle accounts, please be aware that `/scratch` on Swift behaves differently, so adjustments to job scripts may be necessary.
+
+There is NO global/network-accessible `/scratch` path on Swift at this time. If a networked working directory is needed for multi-node jobs, please use /projects. 
+
+The scratch directory on each Swift compute node is a 1.8TB spinning disk, and is accessible only on that node. The default writable path for scratch use is `/scratch/<username>`. 
+
+##
+When a job starts, the environment variable `$TMPDIR` is set to `/scratch/<username>/<jobid>` for the duration of the job. This is temporary space only, and should be purged when your job is complete. 
+
+There is no expectation of data longevity in scratch space, and it is subject to purging once the node is idle. If desired data is stored here during the job, please be sure to copy it to a /projects directory as part of the job script before the job finishes.
+
+
+

--- a/docs/Documentation/Systems/Swift/filesystems.md
+++ b/docs/Documentation/Systems/Swift/filesystems.md
@@ -5,13 +5,16 @@ parent: Systems
 has_children: true
 ---
 
+# Swift Filesystem Architecture Overview
 
+Swift's central storage currently has a capacity of approximately 3PB, served over NFS (Network File System). It is a performant system with 
+multiple read and write cache layers and redundancies for data protection, but it is not a parallel filesystem, unlike Eagle's Lustre configuration.
 
-# Filesystems on Swift
+The underlying filesystem and volume management is via ZFS. Data is protected in ZFS RAID arrangements (raidz3) of 8 storage disks and 3 parity disks. 
 
-Swift's central storage consists of approximately 3PB of NFS-mounted storage, served over NFS (Network File System). The underlying filesystem management is via ZFS. 
+Each Swift fileserver serves a single storage chassis (JBOD, "just a bunch of disks") consisting of multiple spinning disks plus SSD drives for read and write caches. 
 
-Unlike the Lustre-based storage on Eagle, Swift currently does not host a parallel file system.
+Each fileserver is also connected to a second storage chassis to serve as a redundant backup in case the primary fileserver for that storage chassis fails, allowing continued access to the data on the storage chassis until the primary fileserver for that chassis is restored to service.
 
 ## Project Storage: /projects
 
@@ -29,16 +32,23 @@ Project directories are automatically mounted or unmounted via NFS on an "as-nee
 
 ## Scratch Space: /scratch/username and /scratch/username/jobid
 
-For users who also have Eagle accounts, please be aware that `/scratch` on Swift behaves differently, so adjustments to job scripts may be necessary.
+For users who also have Eagle allocations, please be aware that scratch space on Swift behaves differently, so adjustments to job scripts may be necessary. 
 
-There is NO global/network-accessible `/scratch` path on Swift at this time. If a networked working directory is needed for multi-node jobs, please use /projects. 
+The scratch directory on each Swift compute node is a 1.8TB spinning disk, and is accessible only on that node. The default writable path for scratch use is `/scratch/<username>`. There is no global, network-accessible `/scratch` space. `/projects` and `/home` are 
 
-The scratch directory on each Swift compute node is a 1.8TB spinning disk, and is accessible only on that node. The default writable path for scratch use is `/scratch/<username>`. 
 
-##
+## Temporary space: $TMPDIR 
+
 When a job starts, the environment variable `$TMPDIR` is set to `/scratch/<username>/<jobid>` for the duration of the job. This is temporary space only, and should be purged when your job is complete. 
 
 There is no expectation of data longevity in scratch space, and it is subject to purging once the node is idle. If desired data is stored here during the job, please be sure to copy it to a /projects directory as part of the job script before the job finishes.
 
+## Mass Storage System
+
+There is no Mass Storage System for deep archive storage on Swift. However, Swift is expected to be a part of the upcoming Campaign Storage system (VAST storage) in the future, allowing those projects with allocations on Eagle to seamlessly transfer data between clusters, and into the Eagle MSS system.
+
+## Backups and Snapshots
+
+There are no backups or snapshots of data on Swift. Though the system is protected from hardware failure by multiple layers of redundancy, please keep regular backups of important data on Swift, and consider using a Version Control System (such as Git) for important code. 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
         - Systems: Documentation/Systems/index.md
         - Swift:
           - Documentation/Systems/Swift/index.md
+          - Documentation/Systems/Swift/filesystems.md
           - Documentation/Systems/Swift/modules.md
           - Documentation/Systems/Swift/running.md
           - Documentation/Systems/Swift/applications.md


### PR DESCRIPTION
This commit adds a documentation outline for the Swift filesystems, including explanations of /projects and /scratch.