### PR TITLE
Updated Vermilion VASP documentation

### DIFF
--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -666,6 +666,6 @@ wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POTCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POSCAR?token=AAAALJ5WKM2QKC3D44SXIQTBBV7P2  -q -O POSCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/KPOINTS?token=AAAALJ5YTSCJFDHUUZMZY63BBV7NU -q -O KPOINTS
 
-mpirun -npernode 1 vasp_std > vasp.$SLURM_JOB_ID
+mpirun -npernode 1 vasp_std > vasp.$SLURM_JOB_ID.
 
 ```

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -374,7 +374,7 @@ This will give you:
 
 Note the directory might be different. 
 
-In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
+In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "ens7" as the interconnect. The mpirun command looks like this. 
 
 ```
 I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
@@ -464,7 +464,7 @@ This will give you:
 
 Note the directory might be different. 
 
-In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
+In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "ens7" as the interconnect. The mpirun command looks like this. 
 
 ```
 I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -374,10 +374,16 @@ This will give you:
 
 Note the directory might be different. 
 
-In order to specify the network interconnect, we need to use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
+In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
 
 ```
-I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -n 16 vasp_std
+I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
+```
+
+For VASP calculations on a single node, srun is sufficient. However, srun and mpirun produce similar run times. To run with srun for single node calculations, use the following line.
+
+```
+srun -n 16 vasp_std
 ```
 
 Then you need to add calls in your script to set up and point to your data files.  So your final script will look something like the following. Here we download data from NREL's benchmark repository.
@@ -425,7 +431,11 @@ wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POTCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POSCAR?token=AAAALJ5WKM2QKC3D44SXIQTBBV7P2  -q -O POSCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/KPOINTS?token=AAAALJ5YTSCJFDHUUZMZY63BBV7NU -q -O KPOINTS
 
+# mpirun is recommended (necessary for multi-node calculations)
 I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
+
+# srun can be used instead of mpirun for sinlge node calculations
+# srun -n 16 vasp_std
 
 ```
 
@@ -454,10 +464,16 @@ This will give you:
 
 Note the directory might be different. 
 
-In order to specify the network interconnect, we need to use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
+In order to run on more than one node, we need to specify the network interconnect. To do so, use mpirun instead of srun. We want to use "en7" as the interconnect. The mpirun command looks like this. 
 
 ```
-I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -n 16 vasp_std
+I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
+```
+
+For VASP calculations on a single node, srun is sufficient. However, srun and mpirun produce similar run times. To run with srun for single node calculations, use the following line.
+
+```
+srun -n 16 vasp_std
 ```
 
 Then you need to add calls in your script to set up and point to your data files.  So your final script will look something like the following. Here we download data from NREL's benchmark repository.
@@ -505,7 +521,11 @@ wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POTCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/POSCAR?token=AAAALJ5WKM2QKC3D44SXIQTBBV7P2  -q -O POSCAR
 wget https://github.nrel.gov/raw/ESIF-Benchmarks/VASP/master/bench2/input/KPOINTS?token=AAAALJ5YTSCJFDHUUZMZY63BBV7NU -q -O KPOINTS
 
+# mpirun is recommended (necessary for multi-node calculations)
 I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
+
+# srun can be used instead of mpirun for sinlge node calculations
+# srun -n 16 vasp_std
 
 ```
 

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -338,10 +338,10 @@ task    thread             node name  first task    # on node  core
 # Running VASP on Vermilion
 
 A few different versions of VASP are available on Vermilion:
-- [VASP 5 (Intel MPI)](Running-VASP-5-(IntelMPI)-on-CPUs)
-- [VASP 6 (Intel MPI)](Running-VASP-6-(IntelMPI)-on-CPUs)
-- [VASP 6 (Open MPI)](Running-VASP-6-(OpenMPI)-on-CPUs)
-- [VASP 6 on GPUs](Running-VASP-6-GPUs)
+- [VASP 5 (Intel MPI)](#Running-VASP-5-(IntelMPI)-on-CPUs)
+- [VASP 6 (Intel MPI)](#Running-VASP-6-(IntelMPI)-on-CPUs)
+- [VASP 6 (Open MPI)](#Running-VASP-6-(OpenMPI)-on-CPUs)
+- [VASP 6 on GPUs](#Running-VASP-6-GPUs)
 
 Running VASP with Open MPI shows a small improvement compared to running with Intel MPI, and running VASP on GPUs shows an even larger improvement.
 

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -341,7 +341,7 @@ A few different versions of VASP are available on Vermilion:
 - [VASP 5 (Intel MPI)](#Running-VASP-5-(IntelMPI)-on-CPUs)
 - [VASP 6 (Intel MPI)](#Running-VASP-6-(IntelMPI)-on-CPUs)
 - [VASP 6 (Open MPI)](#Running-VASP-6-(OpenMPI)-on-CPUs)
-- [VASP 6 on GPUs](#Running-VASP-6-GPUs)
+- [VASP 6 on GPUs](#Running-VASP-6-on-GPUs)
 
 Running VASP with Open MPI shows a small improvement compared to running with Intel MPI, and running VASP on GPUs shows an even larger improvement.
 

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -551,7 +551,7 @@ This will give you:
 
 Note the directory might be different. 
 
-In order to specify the network interconnect, we need to set the OMPI_MCA_param variable. We want to use "en7" as the interconnect.
+In order to specify the network interconnect, we need to set the OMPI_MCA_param variable. We want to use "ens7" as the interconnect.
 
 ```
 module use /nopt/nrel/apps/220525b/level01/modules/lmod/linux-rocky8-x86_64/gcc/12.1.0

--- a/docs/Documentation/Systems/Vermillion/running.md
+++ b/docs/Documentation/Systems/Vermillion/running.md
@@ -338,9 +338,9 @@ task    thread             node name  first task    # on node  core
 # Running VASP on Vermilion
 
 A few different versions of VASP are available on Vermilion:
-- [VASP 5 (Intel MPI)](#Running-VASP-5-(IntelMPI)-on-CPUs)
-- [VASP 6 (Intel MPI)](#Running-VASP-6-(IntelMPI)-on-CPUs)
-- [VASP 6 (Open MPI)](#Running-VASP-6-(OpenMPI)-on-CPUs)
+- [VASP 5 (Intel MPI)](#Running-VASP-5-with-IntelMPI-on-CPUs)
+- [VASP 6 (Intel MPI)](#Running-VASP-6-with-IntelMPI-on-CPUs)
+- [VASP 6 (Open MPI)](#Running-VASP-6-with-OpenMPI-on-CPUs)
 - [VASP 6 on GPUs](#Running-VASP-6-on-GPUs)
 
 Running VASP with Open MPI shows a small improvement compared to running with Intel MPI, and running VASP on GPUs shows an even larger improvement.
@@ -349,7 +349,7 @@ VASP runs faster on 1 node than on 2 nodes. In some cases, VASP run times on 2 n
 
 If many cores are needed for your VASP calcualtion, it is recommended to run VASP on a singe node in the lg partition (60 cores/node), which provides the largest numbers of cores per node. 
 
-## Running VASP 5 (IntelMPI) on CPUs
+## Running VASP 5 with IntelMPI on CPUs
 
 To load a build of VASP 5 that is compatible with Intel MPI (and other necessary modules):
 
@@ -429,7 +429,7 @@ I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
 
 ```
 
-## Running VASP 6 (IntelMPI) on CPUs
+## Running VASP 6 with IntelMPI on CPUs
 
 To load a build of VASP 6 that is compatible with Intel MPI (and other necessary modules):
 
@@ -509,7 +509,7 @@ I_MPI_OFI_PROVIDER=tcp mpirun -iface ens7 -np 16 vasp_std
 
 ```
 
-## Running VASP 6 (OpenMPI) on CPUs
+## Running VASP 6 with OpenMPI on CPUs
 
 To load a build of VASP 6 that is compatible with Open MPI:
 


### PR DESCRIPTION
Better documentation for reliable multi-node jobs with Intel MPI and Open MPI. Need to compare my updates to Tim's updates to make sure there's no overlap. 