### PR TITLE
Update "Optimized_TF" link in blog post

### DIFF
--- a/docs/blog/2021-05-06-tf.md
+++ b/docs/blog/2021-05-06-tf.md
@@ -17,4 +17,4 @@ pip install --upgrade --no-deps --force-reinstall /nopt/nrel/apps/wheels/tensorf
 These builds provide a significant advantage as illustrated below over the standard `conda` install of TensorFlow. 
 ![Benchmark image](../../assets/images/gpu_ai_benchmark.png)
 
-A recent tutorial was given on this topic, for more information see the [recording](https://web.microsoftstream.com/video/af9b54ae-9158-4075-9f36-9aa2a4412ad0) or checkout the [tutorial materials](https://github.com/NREL/HPC/tree/master/workshops/Optimized_TF)
+A recent tutorial was given on this topic, for more information see the [recording](https://web.microsoftstream.com/video/af9b54ae-9158-4075-9f36-9aa2a4412ad0) or checkout the [tutorial materials](https://github.com/NREL/HPC/tree/master/general/Optimized_TF)


### PR DESCRIPTION
 It's the "tutorial materials" link at the bottom of this page: https://nrel.github.io/HPC/blog/2021-05-06-tf/