### PR TITLE
Transfer documentation for Gurobi

### DIFF
--- a/docs/Documentation/Applications/gurobi.md
+++ b/docs/Documentation/Applications/gurobi.md
@@ -1,7 +1,4 @@
----
-layout: default
-title: Gurobi
----
+# Using the Gurobi Optimizer Solvers
 
 *Gurobi Optimizer is a suite of solvers for mathematical programming.*
 

--- a/docs/Documentation/Applications/gurobi.md
+++ b/docs/Documentation/Applications/gurobi.md
@@ -13,10 +13,11 @@ Gurobi includes a linear programming solver (LP), quadratic programming solver
 programming solver (MILP), mixed-integer quadratic programming solver (MIQP),
 and a mixed-integer quadratically constrained programming solver (MIQCP).
 
-NREL hosts 6 general use (including commercial) and 18 academic/government
-standalone Gurobi licenses. The Gurobi interactive shell will run by typing
-"`gurobi.sh`". Gurobi can also be interfaced with C/C++/Java/MATLAB/R codes by
-linking with the Gurobi libraries.
+Gurobi is available on the Eagle system, which hosts 6 general use (including
+commercial) and 18 academic/government standalone Gurobi licenses. After logging
+onto Eagle, load the Gurobi module using `module load gurobi`.  The Gurobi
+interactive shell is run by typing "`gurobi.sh`". Gurobi can also be interfaced
+with C/C++/Java/MATLAB/R codes by linking with the Gurobi libraries.
 
 For details on Gurobi programming, see the [Gurobi Resource
 Center](https://www.gurobi.com/resource-center/) and [Gurobi

--- a/docs/Documentation/Applications/gurobi.md
+++ b/docs/Documentation/Applications/gurobi.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Gurobi
+---
+
+*Gurobi Optimizer is a suite of solvers for mathematical programming.*
+
+For documentation, forums, and FAQs, see the [Gurobi
+website](https://www.gurobi.com/products/gurobi-optimizer/).
+
+Gurobi includes a linear programming solver (LP), quadratic programming solver
+(QP), quadratically constrained programming solver (QCP), mixed-integer linear
+programming solver (MILP), mixed-integer quadratic programming solver (MIQP),
+and a mixed-integer quadratically constrained programming solver (MIQCP).
+
+NREL hosts 6 general use (including commercial) and 18 academic/government
+standalone Gurobi licenses. The Gurobi interactive shell will run by typing
+"`gurobi.sh`". Gurobi can also be interfaced with C/C++/Java/MATLAB/R codes by
+linking with the Gurobi libraries.
+
+For details on Gurobi programming, see the [Gurobi Resource
+Center](https://www.gurobi.com/resource-center/) and [Gurobi
+documentation](https://www.gurobi.com/documentation/).
+
+## Gurobi and MATLAB
+
+To use the Gurobi solver with MATLAB, make sure you have the Gurobi and MATLAB
+environment modules loaded, then issue the following two commands from the
+MATLAB prompt or your script:
+
+```
+>> grb = getenv('GRB_MATLAB_PATH')
+>> path(path,grb)
+```
+
+## Gurobi and General Algebraic Modeling System
+
+The General Algebraic Modeling System (GAMS) is a high-level modeling system for
+mathematical programming and optimization. The GAMS package installed at NREL
+includes Gurobi solvers. For more information, see [using GAMS](gams.md).
+
+Note that the Gurobi license for this interface is separate from the standalone
+Gurobi license, and supports far more instances.
+
+**Important: When using the Gurobi solver in GAMS, the user should NOT load the
+Gurobi module. Simply using "module load gams" will be enough to load the
+required Gurobi components and access rights.**


### PR DESCRIPTION
Closes #266.  Transferring from CMS was straightforward.  One reference to Eagle was changed to make the documentation more generic: "Eagle hosts 6 general use ... licenses" -> "NREL hosts 6 general use ... licenses".  Link to the Gurobi Getting Started Portal was out of date and has been replaced by two new links: Gurobi Resource Center and Documentation.