### PR TITLE
Add C++ content

### DIFF
--- a/docs/Documentation/Development/Languages/c++.md
+++ b/docs/Documentation/Development/Languages/c++.md
@@ -52,7 +52,7 @@ The following is a summary of available compilers and toolchains.  User are enco
 |-----------|--------------|--------------------------|-------------------|
 | gcc       | `g++`        | `gcc`                    | All               |
 | Intel     | `icpc`       | `comp-intel`             | Eagle             |
-| Intel     | `icpc`       | `intel-oneapi-compilers` | Swift, Vermillion |
+| Intel     | `icpc`       | `intel-oneapi-compilers` | Swift, Vermilion |
 | Intel     | `icpc`       | `comp-intel`             | Eagle             |
 | Cray      | `CC`         | `PrgEnv-cray`            | Kestrel           |
 

--- a/docs/Documentation/Development/Languages/c++.md
+++ b/docs/Documentation/Development/Languages/c++.md
@@ -1,0 +1,59 @@
+# C++
+
+*"C++ is a general-purpose programming language providing a direct and efficient model of hardware combined with facilities for defining lightweight abstractions."*
+  - Bjarne Stroustrup, "The C++ Programming Language, Fourth Edition"
+
+## Getting Started
+
+This section illustrates the process to compile and run a basic C++ program on the HPC systems.
+
+### Hello World
+
+Begin by creating a source file named `hello.cpp` with the following contents:
+
+```c++
+#include <iostream>
+
+int main(void) {
+  std::cout << "Hello, World!\n";
+  return 0;
+}
+```
+
+Next, we must select the compiler to use for compiling our program.  We can choose among GNU, Intel, and Cray compilers, depending on the system that we are using (see [Compilers and Toolchains](#compilers-and-toolchains)).  To see available modules and versions, use `module avail`.  For this example, we will use the `g++` compiler, which is part of GNU's `gcc` package.  We will load the default version of the compiler, which in this case is gcc 10.1:
+
+```
+$ module load gcc
+$ module list
+Currently Loaded Modules:
+  1) gcc/10.1.0
+$ gcc --version | head -1
+gcc (Spack GCC) 10.1.0
+```
+
+With the `gcc` package, the C++ compiler is provided by the `g++` command.  To compile the program, run:
+
+```
+$ g++ hello.cpp -o hello
+```
+
+This creates an executable named `hello`.  Now run the program and observe the output:
+
+```
+$ ./hello
+Hello, World!
+```
+
+## Compilers and Toolchains
+
+The following is a summary of available compilers and toolchains.  User are encouraged to run `module avail` to check for the most up-to-date information on a particular system.
+
+| Toolchain | C++ Compiler | Module                   | Systems           |
+|-----------|--------------|--------------------------|-------------------|
+| gcc       | `g++`        | `gcc`                    | All               |
+| Intel     | `icpc`       | `comp-intel`             | Eagle             |
+| Intel     | `icpc`       | `intel-oneapi-compilers` | Swift, Vermillion |
+| Intel     | `icpc`       | `comp-intel`             | Eagle             |
+| Cray      | `CC`         | `PrgEnv-cray`            | Kestrel           |
+
+For information specific to compiling MPI applications, refer to [MPI](../Programming_Models/mpi.md).


### PR DESCRIPTION
This adds basic C++ content with a minimum hello world example and some information on toolchains/modules.

My preference is to avoid duplicating content for subtopics, so for example I have linked to the MPI page instead of trying to hash out all of the toolchain/MPI lib combinations.  I also prefer to avoid making this a language tutorial, since C++ is so large in scope (especially with the standard library).