### PR TITLE
Update scripts and instructions for Kestrel

### DIFF
--- a/applications/spark/README.md
+++ b/applications/spark/README.md
@@ -2,51 +2,170 @@
 
 The scripts in this directory create ephemeral Apache Spark clusters on HPC compute nodes.
 
+[Prerequisites](#prerequisites) | [Setup](#setup) | [Compute Nodes](#compute-nodes)
+
+[Basic Configuration](#basic-configuration-instructions) | [Advanced Configuration](#advanced-configuration-instructions) | [Run Jobs](#run-jobs)
+
+[Debugging Problems](#debugging-problems) | [Performance Monitoing](#performance-monitoring)
+
+[Resources](#resources)
+
 ## Prerequisites
-The scripts require the Spark software to be installed in a Singularity container. The
+The scripts require the Spark software to be installed in an Apptainer container. The
 `docker` directory includes Dockerfiles that build images derived from the base Apache
 Spark Python and R images. The files have instructions on how to convert the Docker images to
-Singularity.
+Apptainer.
 
-Existing Singularity containers on Eagle:
-- Spark 3.3.1 and Python 3.9 is at `/datasets/images/apache_spark/spark_py39.sif`.
-This image includes the packages `ipython`, `jupyter`, `numpy`, `pandas`, and `pyarrow`.
-- Spark 3.3.1 and R 4.0.4 is at `/datasets/images/apache_spark/spark_r.sif`.
-This image includes the packages `tidyverse`, `sparklyr`, `data.table`, `here`, `janitor`, and
-`skimr`.
+**Note**: If you are running on Eagle, replace `apptainer` with `singularity`. It was rebranded
+and Eagle has the old software.
+
+Kestrel:
+```
+$ module load apptainer
+$ apptainer --help
+```
+Eagle:
+```
+$ module load singularity-container
+$ singularity --help
+```
+
+Existing containers on Kestrel and Eagle:
+
+- Spark 3.5.0 and Python 3.11, 3.12 (default = 3.12):
+  - This image includes the packages `ipython`, `jupyter`, `numpy`, `pandas`, and `pyarrow`.
+  - Kestrel: `/kfs2/pdatasets/images/apache_spark/spark350_py311.sif`
+  - Eagle: `/datasets/images/apache_spark/spark350_py311.sif`
+
+- Spark 3.3.1 and R 4.0.4:
+  - This image includes the packages `tidyverse`, `sparklyr`, `data.table`, `here`, `janitor`, and
+    `skimr`.
+  - Kestrel: `/kfs2/pdatasets/images/apache_spark/spark_r.sif`
+  - Eagle: `/datasets/images/apache_spark/spark_r.sif`
 
 ## Setup
 
 1. Clone the repository:
-```
-$ git clone https://github.com/NREL/HPC.git
-```
+    ```
+    $ git clone https://github.com/NREL/HPC.git
+    ```
+
 2. Change to a directory in `/scratch/$USER`.
+
 3. Add the `spark_scripts` directory to your path.
-```
-$ export PATH=$PATH:<your-repo-path>/HPC/applications/spark/spark_scripts
-```
-4. Copy the `config` file and `conf` directory with the command below. Specify an alternate
-destination directory with `-d <directory>`. This can be done on the login node or compute node.
-```
-$ create_config.sh -c <path-to-spark-container>
-```
+    ```
+    $ export PATH=$PATH:<your-repo-path>/HPC/applications/spark/spark_scripts
+    ```
 
-5. Edit the `config` file if necessary. Note that the rest of this page relies on the setting
+## Compute Nodes
+Consider the type of compute nodes to acquire. If you will be performing large shuffles then
+you must get nodes with fast local storage. A minimum requirement is approximately 500 MB/s.
+
+- Any modern SSD should be sufficient.
+- A spinning disk will be too slow.
+- The Lustre filesystem on Kestrel may be fast enough for some queries.
+- The Lustre filesystem on Eagle is too slow.
+- A RAM drive (`/dev/shm`) will work well for smaller data sizes. Half the node memory is available
+on NREL compute nodes.
+
+### Kestrel
+Standard nodes do not have local storage and are unsuitable if you will shuffle data. By default,
+Spark will write to its tmp filesystem and that will quickly run out of space.
+
+Kestrel has 256 nodes with local SSDs. Pick those if you can. For example, `salloc --tmp=1600G`.
+Refer to the [Kestrel documentation](https://www.nrel.gov/hpc/kestrel-system-configuration.html) for
+more information.
+
+### Eagle
+Standard nodes have spinning disks and are unsuitable if you will shuffle data. `bigmem` and `gpu`
+nodes have fast local SSDs. Use those if you can. For example, `salloc --mem=730G` will acquire
+nodes from either partition. Refer to the [Eagle
+documentation](https://www.nrel.gov/hpc/eagle-system-configuration.html) for
+more information.
+
+## Basic Configuration Instructions
+This section lists instructions that should be sufficient for most cases. Refer to [Advanced
+Instructions](#advanced-instructions) to customize the Spark configuration parameters.
+
+1. Acquire interactive compute nodes. Here are examples using the `debug` partition on Kestrel and
+Eagle with ideal node types.
+
+    Kestrel:
+    ```
+    $ salloc -t 01:00:00 -N2 --account=<your-account> --partition=debug --tmp=1600G
+    ```
+    
+    Eagle:
+    ```
+    $ salloc -t 01:00:00 -N2 --account=<your-account> --partition=debug --mem=730G
+    ```
+
+2. Configure and start the cluster with `configure_and_start_spark.sh`. You can run
+`configure_and_start_spark.sh --help` to see all options.
+
+    This example assumes that you were automatically logged into the first compute node in your
+    allocation by `salloc` and the environment variable `SLURM_JOB_ID` is set.
+    
+    Pass the path of the container that you want to use with the `-c` option.
+
+    ```
+    $ configure_and_start_spark.sh -c /kfs2/pdatasets/images/apache_spark/spark350_py311.sif
+    ```
+
+    **Note**: If you logged into the compute node manually with ssh or are using multiple
+    Slurm allocations, specify the Slurm job IDs on the command line, like this:
+    ```
+    $ configure_and_start_spark.sh -c /kfs2/pdatasets/images/apache_spark/spark350_py311.sif <SLURM_JOB_ID_1> <SLURM_JOB_ID_2>
+    ```
+
+    **Note**: This command creates several directories that are used by the cluster. If you will
+    run multiple clusters simultaneously, be sure to use different base directories. The base
+    directory is the current directory by default, and can be changed with `--directory`.
+
+3. Set this environment variable so that your jobs use the Spark configuration settings that you
+just created.
+    ```
+    $ export SPARK_CONF_DIR=$(pwd)/conf
+    ```
+
+4. Run jobs as described [below](#run-jobs).
+
+## Advanced Configuration Instructions
+This section describes how to run the configuration scripts individually so that you can customize
+any Spark parameter.
+
+1. Acquire compute nodes as discussed above. The rest of the instructions assume that you are
+logged into the first node in the allocation (either through `ssh` or automatically through
+`salloc`).
+
+2. Create a local copy of the configuration files with the command below. Specify an alternate
+destination directory with `-d <directory>`.
+
+    ```
+    $ create_config.sh -c <path-to-spark-container>
+    ```
+
+3. Edit the `config` file if necessary. Note that the rest of this section relies on the setting
 `container_instance_name = spark`.
-6. Consider what type of compute nodes to acquire. If you will be performing large shuffles
-then you must get nodes with fast local storage. `bigmem` and `gpu` nodes have local SSDs that
-can read/write at 2 GB/s. The standard nodes have spinning disks that can only read/write at
-~130 MB/s. Your jobs will fail if you use those nodes. You can consider specifying a RAM disk
-as Spark local storage (`/dev/shm`), but you must be sure you have enough space.
-7. Decide how and when you want to configure your Spark application parameters.
 
-   - Manually specify global settings in `conf`. Note that worker settings in `conf/spark-env.sh`
-   must be set before starting the cluster.
-   - Auto-configure global settings with `configure_spark.sh`. You can run this script after
-   acquiring compute nodes and it will apply settings based on the hardware resources (memory/CPU)
-   of those nodes. Run `configure_spark.sh --help` to see available options.
-   - At runtime when you run `spark-submit` or `pyspark`. Refer to the CLI help.
+4. Optional but recommended: Auto-configure the Spark parameters with `configure_spark.sh`. This
+   will adjust the parameters based on the actual memory and CPU resources in your compute nodes.
+   You can run `configure_spark.sh --help` to see all options.
+
+    ```
+    $ configure_spark.sh 
+    ```
+
+5. Optional: Customize the Spark configuration parameters.
+
+This can be done by:
+
+  - Editing the files in the `conf` directory.
+  - Setting the parameters as CLI options when you run `spark-submit` or `pyspark`. Refer to the
+  CLI help.
+
+**Note**: The only way to customize Spark worker parameters is by editing `conf/spark-env.sh`.
+You must make any changes before starting the cluster.
 
 Here are some parameters in the `conf` files to consider editing:
 
@@ -56,92 +175,68 @@ Here are some parameters in the `conf` files to consider editing:
 
 **spark-env.sh**:
    - `SPARK_LOG_DIR`: The Spark processes will log to this directory.
-   - `SPARK_LOCAL_DIRS`: Spark will write temporary files here. It must be fast. Set it to `/dev/shm`
-     if you want to use a RAM disk. Note that Eagle nodes allow use of half of system memory. Adjust
-     other parameters accordingly.
+   - `SPARK_LOCAL_DIRS`: Spark will write temporary files here. It must be fast. Set it to
+   `/dev/shm` if you want to use a RAM drive. Note that HPC nodes allow use of half of system
+   memory. Adjust other parameters accordingly. If on Kestrel, you may be able to set it to a
+   directory on the Lustre filesystem.
    - `SPARK_WORKER_DIR`: The Spark worker processes will log to this directory
      and use it for scratch space. It is configured to go to `/tmp/scratch` by default. Change it
      or copy the files before relinquishing the nodes if you want to preserve the files. They can
      be useful for debugging errors.
 
 **spark-defaults.conf**:
-   - `spark.executor.cores`: Online recommendations say that there is minimal parallelization benefit
-     if the value is greater than 5. It should be configured in tandem with `spark.executor.memory`
-     so that you maxmize the number of executors on each worker node. 7 executors work well on Eagle
-     nodes (35 out of 36 available cores).
-   - `spark.executor.memory`: Adjust as necessary depending on the type of nodes you acquire. Make
-     it big enough for 7 executors after adjusting for overhead for OS and management processes.
+   - `spark.executor.cores`: Online recommendations say that there is minimal parallelization
+   benefit if the value is greater than 5. It should be configured in tandem with
+   `spark.executor.memory` so that you maxmize the number of executors on each worker node.
+   - `spark.executor.memory`: Adjust as necessary depending on the type of nodes you acquire. 10 GB
+   and 5 cores per executor allow for 7 executors on Eagle and 20 on Kestrel, respectively, and
+   will work well in most cases.
    - `spark.driver.memory`: Adjust as necessary depending on how much data you will pull from Spark
-     into your application.
+   into your application. Some online source recommend making it the same as
+   `spark.executor.memory`.
    - `spark.eventLog.dir` and `spark.history.fs.logDirectory`: These directories must exist and
-     will be used to store Spark history. If this is enabled, you can start a Spark history server
-     after your jobs finish and review all jobs in the Spark UI. Disable these and
-     `spark.eventLog.enabled` if you don't want to preserve the history.
+   will be used to store Spark history. If this is enabled, you can start a Spark history server
+   after your jobs finish and review all jobs in the Spark UI. Disable these and
+   `spark.eventLog.enabled` if you don't want to preserve the history.
    - `spark.sql.execution.arrow.pyspark.enabled`: Set it to `true` if you will use Python and
-     convert Spark DataFrames to Pandas DataFrames.
+   convert Spark DataFrames to Pandas DataFrames.
 
+The Spark documentation and other online resources provide additional information about tuning
+these settings. Some resources are linked [below](#resources).
 
-## Usage
-These instructions assume that you are running in a directory that contains the configuration
-files and directories, and that you've added the `spark_scripts` directory to your `PATH`
-environment variable.
+5. Start the Spark cluster.
+    ```
+    $ start_spark_cluster.sh
+    ```
 
-The start script takes one or more SLURM job IDs as inputs. The script will detect the nodes and
-start the container on each.
+6. Set this environment variable so that your jobs use the Spark configuration settings that you
+just created.
+    ```
+    $ export SPARK_CONF_DIR=$(pwd)/conf
+    ```
+
+7. Run jobs as described [below](#run-jobs).
+
+## Run Jobs
+These instructions assume that have allocated compute nodes and started a Spark cluster.
 
 ### Manual mode
 
-1. Allocate nodes however you'd like (`salloc`, `sbatch`, `srun`).
-
-**Note**: The best way to test this functionality is with an interactive session on bigmem nodes
-in the debug partition.
-
-Example command (2 nodes):
-```
-$ salloc -t 01:00:00 -N2 --account=<your-account> --partition=debug --mem=730G
-```
-
-2. Login to the first compute node if not already there.
-3. Optional: Run `configure_spark.sh` to apply settings based on actual compute node resources.
-The script will check for the environment variable `SLURM_JOB_ID`, which is set by `SLURM` when it
-allocates a node to you. If you ssh'd into the compute node then that variable won't be set.
-Choose the option below that is appropriate for your environment.
-```
-$ configure_spark.sh
-```
-```
-$ configure_spark.sh <SLURM_JOB_ID>
-```
-```
-$ configure_spark.sh <SLURM_JOB_ID1> <SLURM_JOB_ID2>
-```
-4. Start the Spark cluster. Similar to `configure_spark.sh`, this script will check for the
-environment variable `SLURM_JOB_ID`.
-
-Choose the option below that is appropriate for your environment.
-```
-$ start_spark_cluster.sh
-```
-```
-$ start_spark_cluster.sh <SLURM_JOB_ID1>
-```
-```
-$ start_spark_cluster.sh <SLURM_JOB_ID1> <SLURM_JOB_ID2>
-```
-
-5. Load the Singularity environment if you want to run with its software. You can also run in your
+1. Load the Apptainer environment if you want to run with its software. You can also run in your
 own environment as long as you have the same versions of Spark and Python or R.
-```
-$ module load singularity-container
-```
 
-6. If you run in your own environment and want to use the configuration settings created by the
+    ```
+    $ module load apptainer
+    ```
+
+2. If you run in your own environment and want to use the configuration settings created by the
 scripts, set the environment variable `SPARK_CONF_DIR`.
-```
-$ export SPARK_CONF_DIR=$(pwd)/conf
-```
 
-7. Start a Spark process.
+    ```
+    $ export SPARK_CONF_DIR=$(pwd)/conf
+    ```
+
+3. Start a Spark process.
 
 Refer to Python instructions [here](python.md).
 
@@ -155,15 +250,28 @@ Refer to the scripts in the `slurm_scripts` directory.
 ### Mounts
 The configuration scripts mount the following directories inside the container, and so you should
 be able to load data files in any of them:
-- `/lustre`
 - `/projects`
 - `/scratch`
 - `/datasets`
+- `/lustre` (Eagle)
+- `/kfs2` (Kestrel)
+- `/kfs3` (Kestrel)
 
+### Shut down the cluster
+This command will stop the Spark processes and the containers.
+```
+$ stop_spark_cluster.sh
+```
 
 ## Debugging problems
 Open the Spark web UI to observe what's happening with your jobs. You will have to forward ports
-8080 and 4040 of the master node (first node in your SLURM allocation) through an ssh tunnel.
+8080 and 4040 of the master node (first node in your Slurm allocation) through an ssh tunnel.
+
+This is a Mac/Linux example to create a tunnel. On Windows adjust the environment variable syntax as
+needed for the Command shell or PowerShell.
+```
+$ export COMPUTE_NODE=<your-compute-node-name>
+$ ssh -L 4040:$COMPUTE_NODE:4040 -L 8080:$COMPUTE_NODE:8080 $USER@kestrel.hpc.nrel.gov
 
 Open your browser to http://localhost:4040 after configuring the tunnel to access the application UI.
 
@@ -174,13 +282,13 @@ If you enable the history server then you can open this UI after you relinquish 
 is an example of how to start it:
 
 ```
-$ singularity exec \
+$ apptainer exec \
 	--env SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=./events" \
 	instance://spark \
 	start-history-server.sh
 ```
 
-**Note**: Be sure to cleanly shutdown the cluster with `stop_spark_cluster.sh` if you intend
+**Note**: Be sure to gracefully shut down the cluster with `stop_spark_cluster.sh` if you intend
 to look at the history.
 
 ## Performance monitoring
@@ -225,13 +333,14 @@ later. This section describes one way to do that with a separate tool.
 
 1. Configure a Python virtual environment.
 2. Install `jade`.
-```
-$ pip install NREL-jade
-```
-This package includes a tool that collects resource utilization data. You can run it like this:
-```
-$ jade stats collect --interval=1 --output=my-stats
-```
+
+    ```
+    $ pip install NREL-jade
+    ```
+    This package includes a tool that collects resource utilization data. You can run it like this:
+    ```
+    $ jade stats collect --interval=1 --output=my-stats
+    ```
 The tool generates a Parquet file for each resource type as well as HTML plots.
 
 3. Configure your `sbatch` script to run this tool on each node. Refer to the scripts in

--- a/applications/spark/README.md
+++ b/applications/spark/README.md
@@ -69,12 +69,9 @@ you must get nodes with fast local storage. A minimum requirement is approximate
 on NREL compute nodes.
 
 ### Kestrel
-Standard nodes do not have local storage and are unsuitable if you will shuffle data. By default,
-Spark will write to its tmp filesystem and that will quickly run out of space.
-
-Kestrel has 256 nodes with local SSDs. Pick those if you can. For example, `salloc --tmp=1600G`.
-Refer to the [Kestrel documentation](https://www.nrel.gov/hpc/kestrel-system-configuration.html) for
-more information.
+Only 256 out of the 2144 CPU-only Kestrel compute nodes have local SSDs. Pick those if you can. For
+example, `salloc --tmp=1600G`. Refer to the [Kestrel
+documentation](https://www.nrel.gov/hpc/kestrel-system-configuration.html) for more information.
 
 ### Eagle
 Standard nodes have spinning disks and are unsuitable if you will shuffle data. `bigmem` and `gpu`

--- a/applications/spark/config
+++ b/applications/spark/config
@@ -1,4 +1,0 @@
-container = /datasets/images/apache_spark/spark_py39.sif
-container_instance_name = spark
-master_node_memory_overhead_gb = 10
-worker_node_memory_overhead_gb = 5

--- a/applications/spark/docker/python/Dockerfile
+++ b/applications/spark/docker/python/Dockerfile
@@ -2,14 +2,14 @@
 # Do not run this while connected to the VPN.
 # docker build --tag spark .
 
-# This container can be converted to a Singularity container on Eagle with these commands:
+# This container can be converted to an Apptainer container on Eagle with these commands:
 # Save and upload the docker image to Eagle.
 # $ docker save -o spark.tar spark
 # $ scp spark_container.tar <username>@eagle.hpc.nrel.gov:/scratch/<username>
 # Acquire a compute node.
-# $ export SINGULARITY_TMPDIR=/dev/shm
-# $ module load singularity-container
-# $ singularity build spark.sif docker-archive://spark.tar
+# $ export APPTAINER_CACHEDIR=/dev/shm
+# $ module load apptainer
+# $ apptainer build spark.sif docker-archive://spark.tar
 
 # Methodology for operation of this container is based on https://sylabs.io/2018/10/spark-on-singularity/
 

--- a/applications/spark/docker/r/Dockerfile
+++ b/applications/spark/docker/r/Dockerfile
@@ -2,14 +2,14 @@
 # Do not run this while connected to the VPN.
 # docker build --tag spark .
 
-# This container can be converted to a Singularity container on Eagle with these commands:
+# This container can be converted to an Apptainer container on Eagle with these commands:
 # Save and upload the docker image to Eagle.
 # $ docker save -o spark.tar spark
 # $ scp spark_container.tar <username>@eagle.hpc.nrel.gov:/scratch/<username>
 # Acquire a compute node.
-# $ export SINGULARITY_TMPDIR=/dev/shm
-# $ module load singularity-container
-# $ singularity build spark.sif docker-archive://spark.tar
+# $ export APPTAINER_CACHEDIR=/dev/shm
+# $ module load apptainer
+# $ apptainer build spark.sif docker-archive://spark.tar
 
 # Methodology for operation of this container is based on https://sylabs.io/2018/10/spark-on-singularity/
 

--- a/applications/spark/docker/r/Dockerfile
+++ b/applications/spark/docker/r/Dockerfile
@@ -25,6 +25,13 @@ RUN apt-get update \
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN apt-get update
+RUN R -e 'install.packages("dplyr")'
+RUN R -e 'install.packages("tidyr")'
+RUN R -e 'install.packages("ggplot2")'
+RUN R -e 'install.packages("purrr")'
+RUN R -e 'install.packages("dbplyr")'
+RUN R -e 'install.packages("dtplyr")'
+RUN R -e 'install.packages("arrow")'
 RUN R -e 'install.packages("tidyverse")'
 RUN R -e 'install.packages("sparklyr")'
 RUN R -e 'install.packages("data.table")'

--- a/applications/spark/python.md
+++ b/applications/spark/python.md
@@ -1,11 +1,20 @@
 ## Interactive Python interpreter
-This uses ipython, which is optional. Remove the `--env` line to use the regular interpreter.
+The first example below uses ipython, which is optional.
+You can leave the driver unset to use the default Python or set it explicitly based on what is in
+your container.
 ```
-$ singularity run \
+$ apptainer run \
 	--env PYSPARK_DRIVER_PYTHON=ipython \
 	instance://spark \
 	pyspark --master spark://$(hostname):7077
 ```
+```
+$ apptainer run \
+	--env PYSPARK_DRIVER_PYTHON=python3.11 \
+	instance://spark \
+	pyspark --master spark://$(hostname):7077
+```
+
 Optional: check your environment to ensure that all configuration settings are correct.
 Most importantly, ensure that you connected to the Spark cluster master and are not in local mode.
 pyspark prints the connection information during startup. For example:
@@ -26,7 +35,7 @@ In [2]: spark.read.parquet("my_data.parquet")
 
 ## Jupyter notebook
 ```
-$ singularity run \
+$ apptainer run \
 	--net \
 	--network-args "portmap=8889:8889" \
 	--env PYSPARK_DRIVER_PYTHON=jupyter \
@@ -41,7 +50,7 @@ This is a Mac/Linux example. On Windows adjust the environment variable syntax a
 or PowerShell.
 ```
 $ export COMPUTE_NODE=<your-compute-node-name>
-$ ssh -L 4040:$COMPUTE_NODE:4040 -L 8080:$COMPUTE_NODE:8080 -L 8889:$COMPUTE_NODE:8889 $USER@eagle.hpc.nrel.gov
+$ ssh -L 4040:$COMPUTE_NODE:4040 -L 8080:$COMPUTE_NODE:8080 -L 8889:$COMPUTE_NODE:8889 $USER@kestrel.hpc.nrel.gov
 ```
 Open the link in your browser and start a new notebook.
 Connect to the Spark session by entering this text into a cell.
@@ -52,7 +61,7 @@ spark = SparkSession.builder.appName("my_app").getOrCreate()
 
 ## Run a script
 ```
-$ singularity run \
+$ apptainer run \
 	instance://spark \
 	spark-submit --master spark://$(hostname):7077 <your-script>
 ```
@@ -68,13 +77,11 @@ spark = SparkSession.builder.appName("my_app").getOrCreate()
 Apache provides several example scripts. Start a shell inside the container if you'd like to view
 or copy them.
 ```
-$ singularity shell instance://spark
-Singularity> ls /opt/spark/examples/src/main/python/
-Singularity> cat /opt/spark/examples/src/main/python/pi.py
+$ apptainer shell instance://spark
+apptainer> ls /opt/spark/examples/src/main/python/
+apptainer> cat /opt/spark/examples/src/main/python/pi.py
 ```
 
 ## Python performance considerations
 Refer to this Spark documentation if you will convert Spark DataFrames to Pandas DataFrames.
 https://spark.apache.org/docs/latest/api/python/user_guide/sql/arrow_pandas.html
-
-

--- a/applications/spark/r.md
+++ b/applications/spark/r.md
@@ -1,6 +1,6 @@
 ## Interactive R
 ```
-$ singularity run instance://spark sparkR
+$ apptainer run instance://spark sparkR
 > library(sparklyr)
 > sc = spark_connect(master = paste0("spark://",Sys.info()["nodename"],":7077"))
 > df = spark_read_parquet(sc = sc, path = "my_data.parquet", memory = FALSE)

--- a/applications/spark/slurm_scripts/batch_job.sh
+++ b/applications/spark/slurm_scripts/batch_job.sh
@@ -5,12 +5,12 @@
 #SBATCH --output=output_%j.o
 #SBATCH --error=output_%j.e
 #SBATCH --nodes=2
+#SBATCH --tmp=1600G
 #SBATCH --partition=debug
 
-module load singularity-container
+module load apptainer
 SCRIPT_DIR=~/repos/HPC/applications/spark/spark_scripts
-${SCRIPT_DIR}/configure_spark.sh
-${SCRIPT_DIR}/start_spark_cluster.sh
+${SCRIPT_DIR}/configure_and_start_spark.sh
 # This runs an example script inside the container.
-singularity run instance://spark spark-submit --master spark://$(hostname):7077 /opt/spark/examples/src/main/python/pi.py 500
+apptainer run instance://spark spark-submit --master spark://$(hostname):7077 /opt/spark/examples/src/main/python/pi.py 500
 ${SCRIPT_DIR}/stop_spark_cluster.sh

--- a/applications/spark/slurm_scripts/batch_jupyter.sh
+++ b/applications/spark/slurm_scripts/batch_jupyter.sh
@@ -5,13 +5,13 @@
 #SBATCH --output=output_%j.o
 #SBATCH --error=output_%j.e
 #SBATCH --nodes=2
+#SBATCH --tmp=1600G
 #SBATCH --partition=debug
 
-module load singularity-container
+module load apptainer
 SCRIPT_DIR=~/repos/HPC/applications/spark/spark_scripts
-${SCRIPT_DIR}/configure_spark.sh
-${SCRIPT_DIR}/start_spark_cluster.sh
-singularity run \
+${SCRIPT_DIR}/configure_and_start_spark.sh
+apptainer run \
 	--bind /lustre:/lustre \
 	--bind /projects:/projects \
 	--bind /scratch:/scratch \

--- a/applications/spark/slurm_scripts_with_resource_monitoring/batch_job.sh
+++ b/applications/spark/slurm_scripts_with_resource_monitoring/batch_job.sh
@@ -5,18 +5,18 @@
 #SBATCH --output=output_%j.o
 #SBATCH --error=output_%j.e
 #SBATCH --nodes=2
+#SBATCH --tmp=1600G
 #SBATCH --partition=debug
 
-module load singularity-container
+module load apptainer
 SCRIPT_DIR=~/repos/HPC/applications/spark/spark_scripts
 
 rm -f shutdown
 srun collect_stats.sh . &
 
-${SCRIPT_DIR}/configure_spark.sh
-${SCRIPT_DIR}/start_spark_cluster.sh
+${SCRIPT_DIR}/configure_and_start_spark.sh
 # This runs an example script inside the container.
-singularity run instance://spark spark-submit --master spark://$(hostname):7077 /opt/spark/examples/src/main/python/pi.py 500
+apptainer run instance://spark spark-submit --master spark://$(hostname):7077 /opt/spark/examples/src/main/python/pi.py 500
 ${SCRIPT_DIR}/stop_spark_cluster.sh
 
 touch shutdown

--- a/applications/spark/slurm_scripts_with_resource_monitoring/batch_jupyter.sh
+++ b/applications/spark/slurm_scripts_with_resource_monitoring/batch_jupyter.sh
@@ -5,17 +5,17 @@
 #SBATCH --output=output_%j.o
 #SBATCH --error=output_%j.e
 #SBATCH --nodes=2
+#SBATCH --tmp=1600G
 #SBATCH --partition=debug
 
-module load singularity-container
+module load apptainer
 SCRIPT_DIR=~/repos/HPC/applications/spark/spark_scripts
 
 rm -f shutdown
 srun collect_stats.sh . &
 
-${SCRIPT_DIR}/configure_spark.sh
-${SCRIPT_DIR}/start_spark_cluster.sh
-singularity run \
+${SCRIPT_DIR}/configure_and_start_spark.sh
+apptainer run \
     --bind /lustre:/lustre \
     --bind /projects:/projects \
     --bind /scratch:/scratch \

--- a/applications/spark/spark_scripts/common.sh
+++ b/applications/spark/spark_scripts/common.sh
@@ -1,9 +1,3 @@
-export LUSTRE_BIND_MOUNTS="-B /lustre:/lustre \
-    -B /nopt:/nopt \
-    -B /projects:/projects \
-    -B /scratch:/scratch \
-    -B /datasets:/datasets"
-
 function error()
 {
     echo "Error: ${@}"
@@ -29,10 +23,31 @@ function get_config_variable()
     echo "${var}"
 }
 
-export CONTAINER=$(get_config_variable "container")
-export CONTAINER_INSTANCE_NAME=$(get_config_variable "container_instance_name")
-export MASTER_NODE_MEMORY_OVERHEAD_GB=$(get_config_variable "master_node_memory_overhead_gb")
-export WORKER_NODE_MEMORY_OVERHEAD_GB=$(get_config_variable "worker_node_memory_overhead_gb")
+export CONTAINER_PATH=$(get_config_variable "container")
+export CONTAINER_NAME=$(get_config_variable "container_instance_name")
+export NODE_MEMORY_OVERHEAD_GB=$(get_config_variable "node_memory_overhead_gb")
+
+# Note: NREL_CLUSTER is always set on Kestrel nodes.
+# It is not set on Eagle if you ssh into one of your allocated nodes, which is what these
+# scripts do.
+if [ ! -z ${NREL_CLUSTER} ] && [ ${NREL_CLUSTER} == "kestrel" ]; then
+    module load apptainer
+    export CONTAINER_MODULE=apptainer
+    export CONTAINER_EXEC=apptainer
+    export LUSTRE_BIND_MOUNTS=" -B /nopt:/nopt \
+        -B /projects:/projects \
+        -B /scratch:/scratch \
+        -B /kfs2:/kfs2 \
+        -B /kfs3:/kfs3"
+else
+    export CONTAINER_MODULE=singularity-container
+    export CONTAINER_EXEC=singularity
+    export LUSTRE_BIND_MOUNTS=" -B /nopt:/nopt \
+        -B /datasets:/datasets \
+        -B /lustre:/lustre \
+        -B /projects:/projects \
+        -B /scratch:/scratch"
+fi
 
 function get_memory_gb()
 {
@@ -51,6 +66,19 @@ function get_spark_bind_mounts()
     echo "-B ${CONFIG_DIR}/conf/:/opt/spark/conf"
 }
 
+function get_spark_driver_memory_gb()
+{
+    cfile=${CONFIG_DIR}/conf/spark-defaults.conf
+    mem=$(grep ^spark.driver.memory ${cfile} \
+	| sed -E "s/spark.driver.memory\s*=*\s*([[:digit:]]+)g/\1/")
+    echo "${mem}" | grep spark
+    if [[ $? -eq 0 ]]; then
+        echo "Did not find spark.driver.memory in ${cfile}"
+        exit 1
+    fi
+    echo "${mem}"
+}
+
 function exec_spark_process()
 {
     if [ -z ${1} ]; then
@@ -58,10 +86,10 @@ function exec_spark_process()
         exit 1
     fi
     cmd=$@
-    singularity exec \
+    ${CONTAINER_EXEC} exec \
         ${LUSTRE_BIND_MOUNTS} \
         $(get_spark_bind_mounts ${CONFIG_DIR}) \
-        instance://${CONTAINER_INSTANCE_NAME} \
+        instance://${CONTAINER_NAME} \
         ${cmd}
     ret=$?
     if [[ $ret -ne 0 ]]; then

--- a/applications/spark/spark_scripts/configure_and_start_spark.sh
+++ b/applications/spark/spark_scripts/configure_and_start_spark.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+CONFIG_DIR=$(pwd)
+if [ ! -z ${NREL_CLUSTER} ] && [ ${NREL_CLUSTER} == "kestrel" ]; then
+    CONTAINER_PATH="/kfs2/pdatasets/images/apache_spark/spark350_py311.sif"
+else
+    CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
+fi
+CONTAINER_NAME="spark"
+NODE_MEMORY_OVERHEAD_GB=5
+DRIVER_MEMORY_GB=1
+ENABLE_DYNAMIC_ALLOCATION=false
+ENABLE_HISTORY_SERVER=false
+# Many online docs say executors max out with 5 threads.
+EXECUTOR_CORES=5
+PARTITION_MULTIPLIER=1
+SLURM_JOB_IDS=()
+
+# Main
+
+read -r -d "" USAGE << EOM
+Usage: $(basename $0) [OPTIONS]... [SLURM_JOB_ID]...
+
+  Configure settings in spark-defaults.conf based on hardware resources in one or more SLURM job IDs.
+  Reads SLURM_JOB_ID from the environment.
+
+Options:
+  -C, --container-name TEXT           Apptainer instance name [default: ${CONTAINER_NAME}]
+  -c, --container-path TEXT           Apptainer container path [default: ${CONTAINER_PATH}]
+  -d, --directory TEXT                Base config directory [default: current]
+  -o, --node-memory-overhead-gb INTEGER
+                                      Memory to reserve for system processes. [Default: ${NODE_MEMORY_OVERHEAD_GB}]
+  -D, --dynamic-allocation            Enable dynamic resource allocation. [Default: false]
+  -H, --history-server                Enable the history server. [Default: false]
+  -M, --driver-memory-gb INTEGER      Driver memory in GB. [Default: ${DRIVER_MEMORY_GB}]
+  -e, --executor-cores INTEGER        Number of cores per executor. [Default: ${EXECUTOR_CORES}]
+  -m, --partition-multiplier INTEGER  Set spark.sql.shuffle.partitions to number of
+                                      cores multiplied by this value. [Default: ${PARTITION_MULTIPLIER}]
+
+Example:
+  $(basename $0) --driver-memory-gb 2
+EOM
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -C|--container-name)
+      CONTAINER_NAME=$2
+      shift
+      shift
+      ;;
+    -c|--container-path)
+      CONTAINER_PATH=$2
+      shift
+      shift
+      ;;
+    -d|--directory)
+      CONFIG_DIR=$2
+      shift
+      shift
+      ;;
+    -o|--node-memory-overhead-gb)
+      NODE_MEMORY_OVERHEAD_GB=$2
+      shift
+      shift
+      ;;
+    -D|--dynamic-allocation)
+      ENABLE_DYNAMIC_ALLOCATION=true
+      shift
+      ;;
+    -H|--history-server)
+      ENABLE_HISTORY_SERVER=true
+      shift
+      ;;
+    -M|--driver-memory-gb)
+      DRIVER_MEMORY_GB=${2}
+      shift
+      shift
+      ;;
+    -e|--executor-cores)
+      EXECUTOR_CORES=${2}
+      shift
+      shift
+      ;;
+    -m|--shuffle-partitions-multiplier)
+      PARTITION_MULTIPLIER=${2}
+      shift
+      shift
+      ;;
+    -h|--help)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      SLURM_JOB_IDS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+bash ${script_dir}/create_config.sh \
+    -C ${CONTAINER_NAME} \
+    -c ${CONTAINER_PATH} \
+    -d ${CONFIG_DIR} \
+    -o ${NODE_MEMORY_OVERHEAD_GB}
+ret=$?
+
+if [[ ${ret} -ne 0 ]]; then
+    exit ${ret}
+fi
+
+. ${script_dir}/common.sh
+if [ ${ENABLE_DYNAMIC_ALLOCATION} = true ]; then
+    flags="-D"
+else
+    flags=""
+fi
+if [ ${ENABLE_HISTORY_SERVER} = true ]; then
+    flags+=" -H"
+fi
+
+bash ${script_dir}/configure_spark.sh \
+    ${flags} \
+    -M ${DRIVER_MEMORY_GB} \
+    -d ${CONFIG_DIR} \
+    -e ${EXECUTOR_CORES} \
+    -m ${PARTITION_MULTIPLIER} \
+    ${SLURM_JOB_IDS[*]}
+ret=$?
+
+if [[ ${ret} -ne 0 ]]; then
+    exit ${ret}
+fi
+
+bash ${script_dir}/start_spark_cluster.sh -d ${CONFIG_DIR} ${SLURM_JOB_IDS[*]}
+ret=$?
+
+exit ${ret}

--- a/applications/spark/spark_scripts/create_config.sh
+++ b/applications/spark/spark_scripts/create_config.sh
@@ -1,13 +1,42 @@
 #!/bin/bash
 
-CONTAINER=""
+# Creates the base config file and copies the Spark configuration files to the user's directory.
+
+if [ ! -z ${NREL_CLUSTER} ] && [ ${NREL_CLUSTER} == "kestrel" ]; then
+    CONTAINER_PATH="/kfs2/pdatasets/images/apache_spark/spark350_py311.sif"
+else
+    CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
+fi
+CONTAINER_NAME="spark"
 DIRECTORY=$(pwd)
+NODE_MEMORY_OVERHEAD_GB="5"
 ARGS=()
+
+read -r -d "" USAGE << EOM
+Usage: $(basename $0) [OPTIONS]...
+
+  Create base configuration files.
+
+Options:
+  -C, --container-name TEXT            Apptainer instance name [default: ${CONTAINER_NAME}]
+  -c, --container-path TEXT            Apptainer container path [default: ${CONTAINER_PATH}]
+  -d, --directory TEXT                 Base config directory [default: current]
+  -o, --node-memory-overhead-gb INTEGER
+                                       Memory to reserve for system processes. [Default: ${NODE_MEMORY_OVERHEAD_GB}]
+
+Example:
+  $(basename $0) -c /${HOME}/my_container.sif
+EOM
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    -c|--container)
-      CONTAINER=$2
+    -C|--container-name)
+      CONTAINER_NAME=$2
+      shift
+      shift
+      ;;
+    -c|--container-path)
+      CONTAINER_PATH=$2
       shift
       shift
       ;;
@@ -16,8 +45,13 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -o|--node-memory-overhead-gb)
+      NODE_MEMORY_OVERHEAD_GB=$2
+      shift
+      shift
+      ;;
     -h|--help)
-      echo "Usage: $(basename $0) [-c|--container CONTAINER] [-d|--directory CONFIG_DIRECTORY]"
+      echo "${USAGE}"
       exit 0
       shift
       shift
@@ -38,30 +72,24 @@ if ! [ -d ${DIRECTORY} ]; then
     exit 1
 fi
 
-if ! [ -z $CONTAINER ] && ! [ -f ${CONTAINER} ]; then
-    echo "Error: container=${CONTAINER} does not exist"
+if ! [ -f ${CONTAINER_PATH} ]; then
+    echo "Error: container_path=${CONTAINER_PATH} does not exist"
     exit 1
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-CONFIG_DIR=$(dirname ${SCRIPT_DIR})/conf
-CONFIG_FILE=$(dirname ${SCRIPT_DIR})/config
-if [ -z ${CONFIG_DIR} ]; then
-    echo "Error: the directory ${CONFIG_DIR} does not exist"
+CONF_DIR=$(dirname ${SCRIPT_DIR})/conf
+if [ -z ${CONF_DIR} ]; then
+    echo "Error: the directory ${CONF_DIR} does not exist"
     exit 1
 fi
-if [ -z ${CONFIG_FILE} ]; then
-    echo "Error: the file ${CONFIG_FILE} does not exist"
-    exit 1
-fi
-cp -r ${CONFIG_DIR} ${DIRECTORY}
-cp ${CONFIG_FILE} ${DIRECTORY}
+cp -r ${CONF_DIR} ${DIRECTORY}
+CONFIG_FILE="${DIRECTORY}/config"
 
-if [ -z $CONTAINER ]; then
-    CONTAINER=$(grep "container\s*=" ${CONFIG_FILE} | awk -F = '{print $2}' | xargs)
-else
-    tmp_name=${CONTAINER//\//\\\/}
-    sed -i "s/container = .*/container = ${tmp_name}/" ${DIRECTORY}/config
-fi
+echo "" >> ${CONFIG_FILE}
 
-echo "Created configuration files in ${DIRECTORY} with container = ${CONTAINER}"
+echo "container = ${CONTAINER_PATH}" > ${CONFIG_FILE}
+echo "container_instance_name = ${CONTAINER_NAME}" >> ${CONFIG_FILE}
+echo "node_memory_overhead_gb = ${NODE_MEMORY_OVERHEAD_GB}" >> ${CONFIG_FILE}
+
+echo "Created configuration files in ${DIRECTORY}/conf with config file ${CONFIG_FILE}"

--- a/applications/spark/spark_scripts/start_container.sh
+++ b/applications/spark/spark_scripts/start_container.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-module load singularity-container
-
 if [ -z ${1} ]; then
     echo "Error: CONFIG_DIR must be passed to start_container.sh"
     exit 1
@@ -9,12 +7,15 @@ fi
 export CONFIG_DIR=$(realpath ${1})
 export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${SCRIPT_DIR}/common.sh
-echo "Start singularity instance on $(hostname)"
-singularity instance start \
+
+module load ${CONTAINER_MODULE}
+
+echo "Start ${CONTAINER_EXEC} instance on $(hostname)"
+${CONTAINER_EXEC} instance start \
     -B $(mktemp -d ${CONFIG_DIR}/run/`hostname`_XXXX):/run \
     -B ${CONFIG_DIR}/dropbear/:/etc/dropbear \
     ${LUSTRE_BIND_MOUNTS} \
     $(get_spark_bind_mounts ${CONFIG_DIR}) \
-    ${CONTAINER} \
-    ${CONTAINER_INSTANCE_NAME}
-singularity exec instance://${CONTAINER_INSTANCE_NAME} service dropbear start
+    ${CONTAINER_PATH} \
+    ${CONTAINER_NAME}
+${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} service dropbear start

--- a/applications/spark/spark_scripts/start_spark_worker.sh
+++ b/applications/spark/spark_scripts/start_spark_worker.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-module load singularity-container
+export CONFIG_DIR=$(realpath $1)
+export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${SCRIPT_DIR}/common.sh
+
+module load ${CONTAINER_MODULE}
 
 if [ -z ${1} ]; then
     echo "Error: CONFIG_DIR must be passed to start_spark_worker.sh"
     exit 1
 fi
-export CONFIG_DIR=$(realpath $1)
 
 overhead_memory_gb=$2
 spark_cluster=$3
@@ -19,8 +22,6 @@ if [ -z ${spark_cluster} ]; then
     exit 1
 fi
 
-export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-. ${SCRIPT_DIR}/common.sh
 total_memory_gb=$(get_memory_gb)
 memory_gb=$(( ${total_memory_gb} - ${overhead_memory_gb} ))
 echo "Start worker on `hostname` with memory ${memory_gb}g URL=${spark_cluster}"

--- a/applications/spark/spark_scripts/stop_container.sh
+++ b/applications/spark/spark_scripts/stop_container.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-module load singularity-container
-
 if [ -z ${1} ]; then
     echo "Error: CONFIG_DIR must be passed to stop_container.sh"
     exit 1
@@ -10,7 +8,9 @@ export CONFIG_DIR=$(realpath ${1})
 
 export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${SCRIPT_DIR}/common.sh
-echo "Stop singularity instance on $(hostname)"
 
-singularity exec instance://${CONTAINER_INSTANCE_NAME} stop-worker.sh
-singularity instance stop ${CONTAINER_INSTANCE_NAME}
+echo "Stop ${CONTAINER_EXEC} instance on $(hostname)"
+
+module load ${CONTAINER_MODULE}
+${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-worker.sh
+${CONTAINER_EXEC} instance stop ${CONTAINER_NAME}

--- a/applications/spark/spark_scripts/stop_spark_cluster.sh
+++ b/applications/spark/spark_scripts/stop_spark_cluster.sh
@@ -35,18 +35,18 @@ fi
 export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${SCRIPT_DIR}/common.sh
 
-module load singularity-container
+module load ${CONTAINER_MODULE}
 check_history_server_enabled
 if [ $? -eq 0 ]; then
     # Checking for errors is not necessary.
-    singularity exec instance://${CONTAINER_INSTANCE_NAME} stop-history-server.sh
+    ${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-history-server.sh
 fi
 
 # Something about the ssh configuration causes a warning when the Spark
 # scripts ssh to each worker node. It doesn't happen in our ssh commands.
 # Workaround the issue by stopping the Spark worker inside stop_container.sh.
-# singularity exec instance://${CONTAINER_INSTANCE_NAME} stop-all.sh
-singularity exec instance://${CONTAINER_INSTANCE_NAME} stop-master.sh
+# ${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-all.sh
+${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-master.sh
 for node_name in $(cat ${CONFIG_DIR}/conf/workers); do
     ssh ${USER}@${node_name} ${SCRIPT_DIR}/stop_container.sh ${CONFIG_DIR}
 done

--- a/applications/spark/tests/README.md
+++ b/applications/spark/tests/README.md
@@ -1,6 +1,6 @@
 # Instructions
 
-1. Change to this directory on Eagle.
+1. Change to this directory on Kestrel.
 2. Run the tests with a valid account.
 ```
 $ ./run_tests.sh ACCOUNT

--- a/applications/spark/tests/batch_job.sh.template
+++ b/applications/spark/tests/batch_job.sh.template
@@ -8,19 +8,23 @@
 #SBATCH --partition=debug
 #SBATCH --qos=standby
 
-module load singularity-container
+module load apptainer
 SCRIPT_DIR=../../spark_scripts
-${SCRIPT_DIR}/create_config.sh -c /datasets/images/apache_spark/spark_py39.sif
-${SCRIPT_DIR}/configure_spark.sh -H -m 2 --driver-memory-gb 2
+${SCRIPT_DIR}/create_config.sh
+${SCRIPT_DIR}/configure_and_start_spark.sh \
+    -c /kfs2/pdatasets/images/apache_spark/spark350_py311.sif \
+    -H \
+    -m 2 \
+    --driver-memory-gb 2
 ret=$?
 if [ ${ret} -ne 0 ]; then
     echo "Error: Failed to run configure_spark.sh: ${ret}"
     exit 1
 fi
 
-grep "spark.sql.shuffle.partitions 140" conf/spark-defaults.conf
+grep "spark.sql.shuffle.partitions 412" conf/spark-defaults.conf
 if [ ${?} -ne 0 ]; then
-    echo "Number of shuffle partitions should have been (36 cores * 2 nodes - 2) * 2"
+    echo "Number of shuffle partitions should have been (104 cores * 2 nodes - 2) * 2"
     exit 1
 fi
 
@@ -43,14 +47,7 @@ if [ ${?} -eq 0 ]; then
 fi
 echo "Verified Spark configuration settings"
 
-${SCRIPT_DIR}/start_spark_cluster.sh $SLURM_JOB_ID
-ret=$?
-if [ ${ret} -ne 0 ]; then
-    echo "Error: Failed to run start_spark_cluster.sh: ${ret}"
-    exit 1
-fi
-
-singularity run instance://spark spark-submit --master spark://$(hostname):7077 ../test_job.py
+apptainer run instance://spark spark-submit --master spark://$(hostname):7077 ../test_job.py
 ret=$?
 if [ ${ret} -ne 0 ]; then
     echo "Error: Failed to run test_job.py: ${ret}"

--- a/applications/spark/tests/run_tests.sh
+++ b/applications/spark/tests/run_tests.sh
@@ -19,5 +19,9 @@ if [ $? -ne 0 ]; then
 fi
 
 cd run
-sbatch batch_job.sh
-echo "Check results manually when complete and delete the directory ./run."
+output=$(sbatch batch_job.sh)
+echo "${output}"
+job_id=$(echo "${output}" | grep -oE "[0-9]+")
+echo "Monitor for job completion with squeue -j ${job_id}"
+echo "When complete, check results by verifying ExitCode=0 with sacct -j ${job_id}"
+echo "Delete the directory ./run to clean up."


### PR DESCRIPTION
There are two sets of changes in this pull request:
1. Update paths, commands, and instructions for Kestrel. There are also some general documentation improvements.
2. Add the new script, `configure_and_start_spark.sh`, to allow the user to get the cluster running in a single command instead of three. The actual functionality didn’t change much.

I have tested the scripts on Eagle and Kestrel. The included test runs on Kestrel. 