### PR TITLE
Ensure that the Spark scripts exit if a command fails.

### DIFF
--- a/applications/spark/spark_scripts/configure_and_start_spark.sh
+++ b/applications/spark/spark_scripts/configure_and_start_spark.sh
@@ -102,16 +102,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -e
 bash ${script_dir}/create_config.sh \
     -C ${CONTAINER_NAME} \
     -c ${CONTAINER_PATH} \
     -d ${CONFIG_DIR} \
     -o ${NODE_MEMORY_OVERHEAD_GB}
-ret=$?
-
-if [[ ${ret} -ne 0 ]]; then
-    exit ${ret}
-fi
 
 . ${script_dir}/common.sh
 if [ ${ENABLE_DYNAMIC_ALLOCATION} = true ]; then
@@ -130,13 +126,5 @@ bash ${script_dir}/configure_spark.sh \
     -e ${EXECUTOR_CORES} \
     -m ${PARTITION_MULTIPLIER} \
     ${SLURM_JOB_IDS[*]}
-ret=$?
-
-if [[ ${ret} -ne 0 ]]; then
-    exit ${ret}
-fi
 
 bash ${script_dir}/start_spark_cluster.sh -d ${CONFIG_DIR} ${SLURM_JOB_IDS[*]}
-ret=$?
-
-exit ${ret}

--- a/applications/spark/spark_scripts/create_config.sh
+++ b/applications/spark/spark_scripts/create_config.sh
@@ -83,10 +83,9 @@ if [ -z ${CONF_DIR} ]; then
     echo "Error: the directory ${CONF_DIR} does not exist"
     exit 1
 fi
+set -e
 cp -r ${CONF_DIR} ${DIRECTORY}
 CONFIG_FILE="${DIRECTORY}/config"
-
-echo "" >> ${CONFIG_FILE}
 
 echo "container = ${CONTAINER_PATH}" > ${CONFIG_FILE}
 echo "container_instance_name = ${CONTAINER_NAME}" >> ${CONFIG_FILE}

--- a/applications/spark/spark_scripts/start_spark_cluster.sh
+++ b/applications/spark/spark_scripts/start_spark_cluster.sh
@@ -120,7 +120,7 @@ write_worker_nodes
 start_containers
 start_spark_processes
 
-read -r -d "" USAGE << EOM
+cat << EOM
 ###############################################################################
 
 Run this command to use the Spark configuration:
@@ -129,5 +129,3 @@ Run this command to use the Spark configuration:
 
 ###############################################################################
 EOM
-
-echo "${USAGE}"


### PR DESCRIPTION
Fixes #603. The scripts were not exiting-on-error in all situations.