### PR TITLE
Update directories in Spark scripts to match Kestrel changes

### DIFF
--- a/applications/spark/README.md
+++ b/applications/spark/README.md
@@ -32,16 +32,22 @@ $ singularity --help
 
 Existing containers on Kestrel and Eagle:
 
-- Spark 3.5.0 and Python 3.11, 3.12 (default = 3.12):
-  - This image includes the packages `ipython`, `jupyter`, `numpy`, `pandas`, and `pyarrow`.
-  - Kestrel: `/kfs2/pdatasets/images/apache_spark/spark350_py311.sif`
-  - Eagle: `/datasets/images/apache_spark/spark350_py311.sif`
+- Spark 3.5.0 and Python 3.11, 3.12 (default = 3.12)
+
+  This image includes the packages `ipython`, `jupyter`, `numpy`, `pandas`, and `pyarrow`.
+
+  ```
+  /datasets/images/apache_spark/spark350_py311.sif
+  ```
 
 - Spark 3.3.1 and R 4.0.4:
-  - This image includes the packages `tidyverse`, `sparklyr`, `data.table`, `here`, `janitor`, and
-    `skimr`.
-  - Kestrel: `/kfs2/pdatasets/images/apache_spark/spark_r.sif`
-  - Eagle: `/datasets/images/apache_spark/spark_r.sif`
+
+  This image includes the packages `tidyverse`, `sparklyr`, `data.table`, `here`, `janitor`, and
+  `skimr`.
+
+  ```
+  /datasets/images/apache_spark/spark350_py311.sif
+  ```
 
 ## Setup
 
@@ -177,7 +183,7 @@ Here are some parameters in the `conf` files to consider editing:
    memory. Adjust other parameters accordingly. If on Kestrel, you may be able to set it to a
    directory on the Lustre filesystem.
    - `SPARK_WORKER_DIR`: The Spark worker processes will log to this directory
-     and use it for scratch space. It is configured to go to `/tmp/scratch` by default. Change it
+     and use it for scratch space. It is configured to go to `$TMPDIR` by default. Change it
      or copy the files before relinquishing the nodes if you want to preserve the files. They can
      be useful for debugging errors.
 

--- a/applications/spark/conf/spark-env.sh
+++ b/applications/spark/conf/spark-env.sh
@@ -76,8 +76,8 @@
 # - MKL_NUM_THREADS=1        Disable multi-threading of Intel MKL
 # - OPENBLAS_NUM_THREADS=1   Disable multi-threading of OpenBLAS
 
-SPARK_LOCAL_DIRS=/tmp/scratch/spark/local
+SPARK_LOCAL_DIRS=$TMPDIR/spark/local
 SPARK_LOG_DIR=logs
 # In order to preserve worker logs for debugging purposes, change this to a permanent location
 # or copy the files before relinquishing the nodes.
-SPARK_WORKER_DIR=/tmp/scratch/spark/worker
+SPARK_WORKER_DIR=$TMPDIR/spark/worker

--- a/applications/spark/spark_scripts/configure_and_start_spark.sh
+++ b/applications/spark/spark_scripts/configure_and_start_spark.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 CONFIG_DIR=$(pwd)
-if [ ! -z ${NREL_CLUSTER} ] && [ ${NREL_CLUSTER} == "kestrel" ]; then
-    CONTAINER_PATH="/kfs2/pdatasets/images/apache_spark/spark350_py311.sif"
-else
-    CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
-fi
+CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
 CONTAINER_NAME="spark"
 NODE_MEMORY_OVERHEAD_GB=5
 DRIVER_MEMORY_GB=1

--- a/applications/spark/spark_scripts/create_config.sh
+++ b/applications/spark/spark_scripts/create_config.sh
@@ -2,11 +2,7 @@
 
 # Creates the base config file and copies the Spark configuration files to the user's directory.
 
-if [ ! -z ${NREL_CLUSTER} ] && [ ${NREL_CLUSTER} == "kestrel" ]; then
-    CONTAINER_PATH="/kfs2/pdatasets/images/apache_spark/spark350_py311.sif"
-else
-    CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
-fi
+CONTAINER_PATH="/datasets/images/apache_spark/spark350_py311.sif"
 CONTAINER_NAME="spark"
 DIRECTORY=$(pwd)
 NODE_MEMORY_OVERHEAD_GB="5"


### PR DESCRIPTION
The Spark scripts were broken by two recent changes to Kestrel:
- /tmp/scratch is no longer writable.
- Apptainer images were moved to a new location.

I noticed that several other documentation pages and scripts are affected by the change to /tmp/scratch. Is there any chance that `$LOCAL_SCRATCH` (only on Kestrel compute nodes with local storage) can be changed to `$TMPDIR` (instead of /tmp/scratch)? It seems problematic to have that environment variable point to a read-only location.