### PR TITLE
Update Spark scripts to support multiple client connections to the Hive metastore

### DIFF
--- a/applications/spark/spark_scripts/create_config.sh
+++ b/applications/spark/spark_scripts/create_config.sh
@@ -2,10 +2,13 @@
 
 # Creates the base config file and copies the Spark configuration files to the user's directory.
 
-CONTAINER_PATH="/datasets/images/apache_spark/spark352_py311.sif"
+CONTAINER_PATH="/datasets/images/apache_spark/spark354_py311.sif"
 CONTAINER_NAME="spark"
 DIRECTORY=$(pwd)
 NODE_MEMORY_OVERHEAD_GB=10
+ENABLE_DERBY_METASTORE=false
+ENABLE_POSTGRES_METASTORE=false
+POSTGRES_PASSWORD="postgres"
 METASTORE_DIR="."
 ENABLE_THRIFT_SERVER=false
 ARGS=()
@@ -21,8 +24,13 @@ Options:
   -d, --directory TEXT                 Base config directory [default: current]
   -o, --node-memory-overhead-gb INTEGER
                                        Memory to reserve for system processes. [Default: ${NODE_MEMORY_OVERHEAD_GB}]
+  -S, --hive-metastore                Create a Hive metastore with Spark defaults (Apache Derby).
+                                      Supports only one Spark session. [Default: false]
+  -p, --postgres-hive-metastore       Create a metastore with PostgreSQL.
+                                      Supports multiple Spark sessions. [Default: false]
+  -P, --postgres-password TEXT         Password for PostgreSQL. [Default: random string]
   -s, --metastore-dir TEXT             Set a custom directory for the metastore and warehouse. [Default: current]
-  -t, --thrift-server TEXT             Enable the Thrift server to connect a SQL client. [Default: false]
+  -t, --thrift-server                  Enable the Thrift server to connect a SQL client. [Default: false]
 
 Example:
   $(basename $0) -c /${HOME}/my_container.sif
@@ -52,6 +60,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     -s|--metastore-dir)
       METASTORE_DIR=$2
+      shift
+      shift
+      ;;
+    -S|--hive-metastore)
+      ENABLE_DERBY_METASTORE=true
+      shift
+      ;;
+    -p|--postgres-hive-metastore)
+      ENABLE_POSTGRES_METASTORE=true
+      shift
+      ;;
+    -P|--postgres-password)
+      POSTGRES_PASSWORD=$2
       shift
       shift
       ;;
@@ -96,9 +117,18 @@ set -e
 cp -r ${CONF_DIR} ${DIRECTORY}
 CONFIG_FILE="${DIRECTORY}/config"
 
+if [ ${POSTGRES_PASSWORD} == "postgres" ]; then
+    POSTGRES_PASSWORD=$(openssl rand -base64 10 | tr -dc 'a-zA-Z0-9' | head -c 10)
+fi
+
 echo "container = ${CONTAINER_PATH}" > ${CONFIG_FILE}
 echo "container_instance_name = ${CONTAINER_NAME}" >> ${CONFIG_FILE}
 echo "node_memory_overhead_gb = ${NODE_MEMORY_OVERHEAD_GB}" >> ${CONFIG_FILE}
+echo "enable_derby_metastore = ${ENABLE_DERBY_METASTORE}" >> ${CONFIG_FILE}
+echo "enable_postgres_metastore = ${ENABLE_POSTGRES_METASTORE}" >> ${CONFIG_FILE}
+echo "postgres_password = ${POSTGRES_PASSWORD}" >> ${CONFIG_FILE}
+echo "postgres_data_dir = ${DIRECTORY}/pg-data" >> ${CONFIG_FILE}
+echo "postgres_run_dir = ${DIRECTORY}/pg-run" >> ${CONFIG_FILE}
 echo "metastore_dir = ${METASTORE_DIR}" >> ${CONFIG_FILE}
 echo "thrift_server = ${ENABLE_THRIFT_SERVER}" >> ${CONFIG_FILE}
 

--- a/applications/spark/spark_scripts/stop_container.sh
+++ b/applications/spark/spark_scripts/stop_container.sh
@@ -9,8 +9,14 @@ export CONFIG_DIR=$(realpath ${1})
 export SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${SCRIPT_DIR}/common.sh
 
-echo "Stop ${CONTAINER_EXEC} instance on $(hostname)"
+echo "Stop apptainer instance on $(hostname)"
 
 module load ${CONTAINER_MODULE}
-${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-worker.sh
-${CONTAINER_EXEC} instance stop ${CONTAINER_NAME}
+apptainer exec instance://${CONTAINER_NAME} stop-worker.sh
+apptainer instance stop ${CONTAINER_NAME}
+
+enable_pg=$(get_config_variable "enable_postgres_metastore")
+if ${enable_pg}; then
+    apptainer exec instance://pg-server pg_ctl stop
+    apptainer instance stop pg-server
+fi

--- a/applications/spark/spark_scripts/stop_spark_cluster.sh
+++ b/applications/spark/spark_scripts/stop_spark_cluster.sh
@@ -39,7 +39,7 @@ module load ${CONTAINER_MODULE}
 check_history_server_enabled
 if [ $? -eq 0 ]; then
     # Checking for errors is not necessary.
-    ${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-history-server.sh
+    apptainer exec instance://${CONTAINER_NAME} stop-history-server.sh
 fi
 enable_thrift_server=$(get_config_variable "thrift_server")
 if [ ${enable_thrift_server} == "true" ]; then
@@ -49,8 +49,8 @@ fi
 # Something about the ssh configuration causes a warning when the Spark
 # scripts ssh to each worker node. It doesn't happen in our ssh commands.
 # Workaround the issue by stopping the Spark worker inside stop_container.sh.
-# ${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-all.sh
-${CONTAINER_EXEC} exec instance://${CONTAINER_NAME} stop-master.sh
+# apptainer exec instance://${CONTAINER_NAME} stop-all.sh
+apptainer exec instance://${CONTAINER_NAME} stop-master.sh
 ${SCRIPT_DIR}/stop_container.sh ${CONFIG_DIR}
 for node_name in $(cat ${CONFIG_DIR}/conf/workers); do
     if [ ${node_name} != $(hostname) ]; then


### PR DESCRIPTION
This PR adds an option to the Spark startup scripts to to use PostgreSQL for the optional Hive Metastore. The default metastore allows only one client at a time. If Postgres is used, multiple clients can connect. One of my applications that uses these scripts needs simultaneous connections through one Python client and one Hive client.

The scripts download the latest PostgreSQL Docker container through Apptainer and start it on the same compute node as the Spark master process.

I also updated the Spark container image to use the newest version of Spark.