### PR TITLE
adding LAMMPs HBW partition documentation/example script

### DIFF
--- a/docs/Documentation/Applications/lammps.md
+++ b/docs/Documentation/Applications/lammps.md
@@ -87,7 +87,7 @@ When running LAMMPs on more than 10 nodes, it is recommended to run LAMMPs on th
 #SBATCH --job-name lammps-16nodes-96ranks
 #SBATCH --nodes=16
 #SBATCH --time=01:30:00
-#SBATCH --account=[your allocation name here]
+#SBATCH --account=<your allocation name here>
 #SBATCH --error=std.err
 #SBATCH --output=std.out
 #SBATCH --tasks-per-node=96


### PR DESCRIPTION
Added documentation for running LAMMPs on the HBW nodes and gave a sample script - I made sure to include the MPICH_OFI_NIC_POLICY and CPUBINDING variables in there, as that gives extra performance gains on the high-bandwidth nodes. In addition, I kept the job-array formatting of the slurm script in there, so that users can see that they wouldn't necessarily need to submit the same job 5 separate times. 