### PR TITLE
gpubuildandrun.md - works with current modules, f90_advanced.md - rm …

### DIFF
--- a/docs/Documentation/Development/Languages/Fortran/f90_advanced.md
+++ b/docs/Documentation/Development/Languages/Fortran/f90_advanced.md
@@ -2822,7 +2822,6 @@ end
 
 ## References
 - [http://www.fortran.com/fortran/](http://www.fortran.com/fortran/) Pointer to everything Fortran
-- [http://meteora.ucsd.edu/~pierce/fxdr_home_page.html](http://meteora.ucsd.edu/~pierce/fxdr_home_page.html) Subroutines to do unformatted I/O across platforms, provided by David Pierce at UCSD
 - [http://www.nsc.liu.se/~boein/f77to90/a5.html](http://www.nsc.liu.se/~boein/f77to90/a5.html) A good reference for intrinsic functions
 - [https://wg5-fortran.org/N1551-N1600/N1579.pdf](https://wg5-fortran.org/N1551-N1600/N1579.pdf)New Features of Fortran 2003
 - [https://wg5-fortran.org/N1701-N1750/N1729.pdf](https://wg5-fortran.org/N1701-N1750/N1729.pdf)New Features of Fortran 2008
@@ -2830,8 +2829,6 @@ end
 - <b>Fortran 90 Handbook Complete ANSI/ISO Reference</b>. Jeanne Adams, Walt Brainerd, Jeanne Martin, Brian Smith, Jerrold Wagener
 - <b>Fortran 90 Programming</b>. T. Ellis, Ivor Philips, Thomas Lahey
 - [https://github.com/llvm/llvm-project/blob/master/flang/docs/FortranForCProgrammers.md](https://github.com/llvm/llvm-project/blob/master/flang/docs/FortranForCProgrammers.md)
-- [FFT stuff](../mkl/)
-- [Fortran 95 and beyond](../95/)
 
 <!-- 
 - [French Translation provided by Mary Orban](http://www.pkwteile.ch/science/avancee-fortran-90/)

--- a/docs/Documentation/Systems/Kestrel/Environments/Toolchains/intel.md
+++ b/docs/Documentation/Systems/Kestrel/Environments/Toolchains/intel.md
@@ -17,7 +17,7 @@ These are the module you will need for compiles:
 ```
 module load  intel-oneapi-compilers 
 module load intel-oneapi-mpi        
-module load gcc/13.1.0                     
+module load gcc                     
 ```
 
 Intel compilers use some gcc functionality so  we load gcc to give a newer version of that compiler.

--- a/docs/Documentation/Systems/Kestrel/Environments/Toolchains/intel.md
+++ b/docs/Documentation/Systems/Kestrel/Environments/Toolchains/intel.md
@@ -62,7 +62,8 @@ We can compile with the extra flag.
 mpiicc -diag-disable=10441 -O3 -g -fopenmp  ex1.c   -o gex_c
 ```
 
-#### 2b. Older compiler (icc) might not be avialable
+#### 2b. Older compiler (icc) might not be available
+
 
 Depending on the version of compilers loaded the message shown above might be replaced with one saying that the icx is no longer available.  In this case you **MUST** use icx.  There are two ways to do that shown below.  
 


### PR DESCRIPTION
gpubuildandrun.md - works with current modules, f90_advanced.md - rm broken links, intel.md - ml gcc instead of gcc13