### PR TITLE
Update openfoam.md

### DIFF
--- a/docs/Documentation/Applications/openfoam.md
+++ b/docs/Documentation/Applications/openfoam.md
@@ -78,7 +78,6 @@ CPU $ module avail openfoam
     #SBATCH --mail-user=<yourEmailAddress>@nrel.gov 
     #SBATCH --nodes=2
     #SBATCH --ntasks-per-node=104 # set number of MPI ranks per node
-    #SBATCH --cpus-per-task=1 # set number of OpenMP threads per MPI rank
     #SBATCH --time=04:00:00
     
     


### PR DESCRIPTION
Removed "#SBATCH --cpus-per-task=1 # set number of OpenMP threads per MPI rank" from the job submission script. This causes the "potentialFoam" command in v2412 to crash when built with mpich. So it is best to not have that at all. Thanks.