### PR TITLE
Clarifying No snapshots/backups on Kestrel HFS

### DIFF
--- a/docs/Documentation/Systems/Kestrel/Filesystems/index.md
+++ b/docs/Documentation/Systems/Kestrel/Filesystems/index.md
@@ -7,7 +7,7 @@ title: Filesystems
 
 ## Home File System
 
-The Home File System (HFS) on Kestrel is part of the ClusterStor used for the Parallel File System (PFS), providing highly reliable storage for user home directories and NREL-specific software. HFS has 1.2 petabytes (PB) of capacity. Snapshots of files on the HFS are available up to 30 days after change/deletion. 
+The Home File System (HFS) on Kestrel is part of the ClusterStor used for the Parallel File System (PFS), providing highly reliable storage for user home directories and NREL-specific software. HFS has 1.2 petabytes (PB) of capacity.
 
 **/home**
 

--- a/docs/Documentation/Systems/Kestrel/Filesystems/index.md
+++ b/docs/Documentation/Systems/Kestrel/Filesystems/index.md
@@ -116,6 +116,6 @@ To request nodes with local disk, use the `--tmp` option in your job submission 
 
 ## Backups and Snapshots
 
-There are no backups nor snapshots of the Kestrel FS. Though the system is protected from hardware failure by multiple layers of redundancy, please regularly back up important data put on Kestrel, and consider using a Version Control System (such as Git) for important code.
+There are no backups nor snapshots of the Kestrel filesystems. Though the system is protected from hardware failure by multiple layers of redundancy, please regularly back up important data put on Kestrel, and consider using a Version Control System (such as Git) for important code.
 
 

--- a/docs/Documentation/Systems/Kestrel/Filesystems/index.md
+++ b/docs/Documentation/Systems/Kestrel/Filesystems/index.md
@@ -114,5 +114,8 @@ The local disk on nodes that have one is mounted at `/tmp/scratch`. To write to 
 
 To request nodes with local disk, use the `--tmp` option in your job submission script. (e.g. `--tmp=1600000`). For more information about requesting this feature, please see the [Running on Kestrel page](../Running/index.md).
 
+## Backups and Snapshots
+
+There are no backups nor snapshots of the Kestrel FS. Though the system is protected from hardware failure by multiple layers of redundancy, please regularly back up important data put on Kestrel, and consider using a Version Control System (such as Git) for important code.
 
 


### PR DESCRIPTION
Does not seem to be any other mentions of the snapshots or backups anywhere else. 

I noticed that there is [a section in the Swift filesystem docs](https://github.com/NREL/HPC/blob/68599fbc61b2712d521dfbc4ffceab7392500426/docs/Documentation/Systems/Swift/filesystems.md?plain=1#L50) directly clarifying there is not backups or snapshots on Swift. Should something be added to this Kestrel section as well?