### PR TITLE
Fix Broken Links on the Slurm Batch Page

### DIFF
--- a/docs/Documentation/Slurm/batch_jobs.md
+++ b/docs/Documentation/Slurm/batch_jobs.md
@@ -11,13 +11,13 @@ Batch jobs are run by submitting a job script to the scheduler with the `sbatch`
 
 Once submitted, the scheduler will insert your job script into the queue to be run at some point in the future, based on priority and how many jobs are in the queue currently.
 
-Priority factors vary on a cluster-by-cluster basis, but typically include a "fairshare" value based on the resources assigned to the allocation, as well as weighting by the job's age, partition, resources (e.g. node count) and/or Quality of Service (qos) factor. Please see the [Monitoring and Control commands](monitor_and_control) page for more information on checking your job's priority. The [Systems](../Systems/) documentation for each cluster will also have more information about the priority weighting, QOS factors, and any associated AU upcharges. 
+Priority factors vary on a cluster-by-cluster basis, but typically include a "fairshare" value based on the resources assigned to the allocation, as well as weighting by the job's age, partition, resources (e.g. node count) and/or Quality of Service (qos) factor. Please see the [Monitoring and Control commands](./monitor_and_control.md) page for more information on checking your job's priority. The [Systems](../Systems/index.md) documentation for each cluster will also have more information about the priority weighting, QOS factors, and any associated AU upcharges. 
 
 To submit batch jobs on an HPC system at NREL, the Slurm `sbatch` command should be used:
 
 `$ sbatch --account=<project-handle> <batch_script>`
 
-Sbatch scripts may be stored on or run from any file system (/home or /projects, for example), as they are typically fairly lightweight shell scripts. However, on most HPC systems it's generally a good idea to have your executables, conda environments, other software that your sbatch script executes stored in a /projects directory. Your input and output files should typically be read from and/or written to either /projects or /scratch directories, as well. Please see the appropriate [Systems](/Documentation/Systems/) page for more information specific to the filesystems on the NREL-hosted cluster you're working on to maximize I/O performance.
+Sbatch scripts may be stored on or run from any file system (/home or /projects, for example), as they are typically fairly lightweight shell scripts. However, on most HPC systems it's generally a good idea to have your executables, conda environments, other software that your sbatch script executes stored in a /projects directory. Your input and output files should typically be read from and/or written to either /projects or /scratch directories, as well. Please see the appropriate [Systems](../Systems/index.md) page for more information specific to the filesystems on the NREL-hosted cluster you're working on to maximize I/O performance.
 
 Arguments to `sbatch` may be used to specify resource limits such as job duration (referred to as "walltime"), number of nodes, etc., as well as what hardware features you want your job to run with. These can also be supplied within the script itself by placing #SBATCH comment directives within the file. 
 


### PR DESCRIPTION
This is a quick branch to fix a couple broken links on the [Slurm Batch Page](https://nrel.github.io/HPC/Documentation/Slurm/batch_jobs/). 

I also noticed that there was a hyperlink that was in a different style than the others, so I brought it more in-line even though it worked as it was. 

Let me know if you want that second change undone or need any other changes I missed. 