### PR TITLE
Add numpy import to testPytorchMPI.py

### DIFF
--- a/docs/Documentation/Machine_Learning/metadata/testPytorchMPI.py
+++ b/docs/Documentation/Machine_Learning/metadata/testPytorchMPI.py
@@ -1,3 +1,4 @@
+import numpy
 import torch
 import torch.distributed as dist
 


### PR DESCRIPTION
Explicitly load numpy before torch. Else numpy cannot find c++ compiler paths correctly if it gets indirectly loaded by pytorch.