### PR TITLE
Update Hosts and Links to NLR Equivalents

### DIFF
--- a/docs/Documentation/Applications/LBMcfd.md
+++ b/docs/Documentation/Applications/LBMcfd.md
@@ -63,7 +63,7 @@ $ git clone https://github.com/nileshsawant/marblesThermal
 
 To install the latest development version of MARBLES, the code has to be built on a GPU login node. Please do the following:
 ```
-$ ssh -X <username>@kestrel-gpu.hpc.nrel.gov
+$ ssh -X <username>@kestrel-gpu.hpc.nlr.gov
 $ module load PrgEnv-gnu/8.5.0
 $ module load cuda/12.3
 $ module load craype-x86-milan

--- a/docs/Documentation/Applications/Plexos/run_plexos.md
+++ b/docs/Documentation/Applications/Plexos/run_plexos.md
@@ -99,7 +99,7 @@ We will run the same example by submitting the job to the SLURM queue. This exam
 
     ```bash
     # SSH into Kestrel or your cluster of choice
-    ssh $USER@kestrel.hpc.nrel.gov
+    ssh $USER@kestrel.hpc.nlr.gov
 
     # Clone the HPC master branch in your scratch folder
     cd /scratch/${USER}/
@@ -118,7 +118,7 @@ This builds upon the previous example where it tries to run the same model as be
 
     ```bash
     # Skip this if you already have the repo cloned in your scratch directory
-    ssh $USER@kestrel.hpc.nrel.gov
+    ssh $USER@kestrel.hpc.nlr.gov
     cd /scratch/${USER}/
     git clone git@github.com:NREL/HPC.git
 
@@ -135,7 +135,7 @@ This example demonstrates how to submit multiple PLEXOS jobs. The model names ar
 
     ```bash
     # Skip this if you already have the repo cloned in your scratch directory
-    ssh $USER@kestrel.hpc.nrel.gov
+    ssh $USER@kestrel.hpc.nlr.gov
     cd /scratch/${USER}/
     git clone git@github.com:NREL/HPC.git
 
@@ -152,7 +152,7 @@ This example demonstrates the use of SLURM job arrays to run multiple PLEXOS job
 
     ```bash
     # Skip this if you already have the repo cloned in your scratch directory
-    ssh $USER@kestrel.hpc.nrel.gov
+    ssh $USER@kestrel.hpc.nlr.gov
     cd /scratch/${USER}/
     git clone git@github.com:NREL/HPC.git
 

--- a/docs/Documentation/Applications/Plexos/setup_plexos.md
+++ b/docs/Documentation/Applications/Plexos/setup_plexos.md
@@ -27,7 +27,7 @@ Before we can run PLEXOS, we need to create a license file on the cluster. For t
     echo '<?xml version="1.0"?>
     <XmlRegistryRoot>
       <comms>
-        <licServer_IP val="plexos.hpc.nrel.gov" />
+        <licServer_IP val="plexos.hpc.nlr.gov" />
         <licServer_CommsPort val="8888" />
         <licServer_IP_Secondary />
         <connect>

--- a/docs/Documentation/Applications/chemicalKinetics.md
+++ b/docs/Documentation/Applications/chemicalKinetics.md
@@ -68,7 +68,7 @@ $ conda deactivate
 ```
 ??? example "[Example interactive jupyter usage](../Development/Jupyter/index.md)"
 	```
-	$ ssh username@kestrel.hpc.nrel.gov
+	$ ssh username@kestrel.hpc.nlr.gov
 	```
 	To access your scratch from the jupyter notebook, execute the following from your Kestrel home directory (optional)
 	```
@@ -82,7 +82,7 @@ $ conda deactivate
 	```
 	$ python -m ipykernel install --user --name=ct-env
 	```
-	In a browser, go to [Kestrel JupyterHub](https://kestrel-jhub.hpc.nrel.gov/), select “ct-env” in the Notebook section to open a new jupyter notebook with the ‘ct-env’ loaded
+	In a browser, go to [Kestrel JupyterHub](https://kestrel-jhub.hpc.nlr.gov/), select “ct-env” in the Notebook section to open a new jupyter notebook with the ‘ct-env’ loaded
 
 	Try Cantera python API within the notebook, for example,
 	```
@@ -106,7 +106,7 @@ $ g++ demo.cpp -o demo $(pkg-config --cflags --libs cantera) && ./demo
 
 ??? example "[Example interactive C++ usage](https://www.nlr.gov/hpc/running-jobs.html)"
 	```
-	$ ssh username@kestrel.hpc.nrel.gov
+	$ ssh username@kestrel.hpc.nlr.gov
 	```
 	Allocate resources
 	```

--- a/docs/Documentation/Applications/comsol.md
+++ b/docs/Documentation/Applications/comsol.md
@@ -22,7 +22,7 @@ Before beginning, it is a good practice to check the license status. To do so, y
 [user@kl3 ~]$ ./lmstat.comsol
 ```
 
-When licenses are available, COMSOL can be used by starting the COMSOL GUI which allows you to build models, run the COMSOL computational engine, and analyze results. The COMSOL GUI can be accessed through a [FastX desktop](https://kestrel-dav.hpc.nrel.gov/auth/ssh/) by opening a terminal in a FastX window and running the following commands:
+When licenses are available, COMSOL can be used by starting the COMSOL GUI which allows you to build models, run the COMSOL computational engine, and analyze results. The COMSOL GUI can be accessed through a [FastX desktop](https://kestrel-dav.hpc.nlr.gov/auth/ssh/) by opening a terminal in a FastX window and running the following commands:
 
 ```
 [user@kl3 ~]$ module load comsol

--- a/docs/Documentation/Applications/vasp.md
+++ b/docs/Documentation/Applications/vasp.md
@@ -149,7 +149,7 @@ CPU $ module avail vasp
 
 !!! tip "Important"
 	Submit GPU jobs from a [GPU login node](../Systems/Kestrel/index.md).
-    `$ ssh <username>@kestrel-gpu.hpc.nrel.gov`
+    `$ ssh <username>@kestrel-gpu.hpc.nlr.gov`
 
 There are several modules for GPU builds of VASP 5 and VASP 6: 
 

--- a/docs/Documentation/Development/Containers/apptainer.md
+++ b/docs/Documentation/Development/Containers/apptainer.md
@@ -19,7 +19,7 @@ Input commands are preceded by a `$`.
 ##### Allocate a compute node.
 
 ```
-$ ssh USERNAME@kestrel.hpc.nrel.gov
+$ ssh USERNAME@kestrel.hpc.nlr.gov
 [USERNAME@kl1 ~]$ salloc --exclusive --mem=0 --tasks-per-node=104 --nodes=1 --time=01:00:00 --account=MYACCOUNT --partition=debug
 [USERNAME@x1000c0s0b0n0 ~]$ cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.6 (Ootpa)

--- a/docs/Documentation/Development/Containers/index.md
+++ b/docs/Documentation/Development/Containers/index.md
@@ -83,7 +83,7 @@ tar czf simple_python3.tar.gz simple_python3.tar
 Now that the exported Docker image is compressed to `.tar.gz` format, you will need to transfer it to one of NLR's HPC systems. Considering the [scratch space](../../Systems/Kestrel/Filesystems/index.md#scratchfs) of [Kestrel](../../Systems/Kestrel/index.md) as an example destination, we will use `rsync` as the transfer method. Be sure to replace `USERNAME` with your unique HPC username:
 
 ```
-rsync -aP --no-g simple_python3.tar.gz USERNAME@kestrel.hpc.nrel.gov:/scratch/USERNAME/
+rsync -aP --no-g simple_python3.tar.gz USERNAME@kestrel.hpc.nlr.gov:/scratch/USERNAME/
 ```
 
 For more information on alternatives to `rsync` (such as FileZilla or Globus), please refer to our [documentation regarding file transfers](../../Managing_Data/Transferring_Files/index.md).

--- a/docs/Documentation/Development/Jupyter/index.md
+++ b/docs/Documentation/Development/Jupyter/index.md
@@ -88,7 +88,7 @@ KJHub is available from the NLR VPN (onsite or offsite) for internal NLR users.
 
 This service is not directly accessible externally for non-NLR HPC users. However, it may be reached by using the [HPC VPN](https://www.nlr.gov/hpc/vpn-connection.html), or by using a [FastX Remote Desktop](../../Viz_Analytics/virtualgl_fastx.md) session via the DAV nodes.
 
-The JupyterHub service is accessible via web browser at [https://kestrel-jhub.hpc.nrel.gov](https://kestrel-jhub.hpc.nrel.gov)
+The JupyterHub service is accessible via web browser at [https://kestrel-jhub.hpc.nlr.gov](https://kestrel-jhub.hpc.nlr.gov)
 
 ### JupyterHub Advantages:
 
@@ -105,7 +105,7 @@ The JupyterHub service is accessible via web browser at [https://kestrel-jhub.hp
    
 ### Simple Instructions to access JupyterHub:
     
-* Visit [https://kestrel-jhub.hpc.nrel.gov](https://kestrel-jhub.hpc.nrel.gov/) in a web browser and log in using your HPC credentials.
+* Visit [https://kestrel-jhub.hpc.nlr.gov](https://kestrel-jhub.hpc.nlr.gov/) in a web browser and log in using your HPC credentials.
    
 KJHub opens a standard JupyterLab interface by default. Change the url ending from "/lab" to "/tree" in your web browser to switch to the classic Notebooks interface.
 
@@ -132,7 +132,7 @@ Before you get started, we recommend installing your own Jupyter inside of a con
 
 Internal (NLR) HPC users on the NLR VPN, or external users of the HPC VPN, may use the instructions below.
 
-External (non-NLR) HPC users may follow the same instructions, but please use `kestrel.nlr.gov` in place of `kestrel.hpc.nrel.gov`.
+-External (non-NLR) HPC users may follow the same instructions, but please use `kestrel.nlr.gov` in place of `kestrel.hpc.nlr.gov`.
 
 ## Using a Compute Node to run Jupyter Notebooks
 
@@ -145,7 +145,7 @@ The examples below will start a 2-hour job. Edit the `<account>` to the name of 
 
 Connect to the login node and launch an interactive job:
 
-`[user@laptop:~]$ ssh kestrel.hpc.nrel.gov`
+`[user@laptop:~]$ ssh kestrel.hpc.nlr.gov`
 
 `[user@kl1:~]$ salloc -A <account> -t 02:00:00`
 
@@ -170,7 +170,7 @@ The `<alphabet soup>` is a long string of letters and numbers. This is a unique 
 
 Next, open an SSH tunnel through a login node to the compute node. Log in when prompted using your regular HPC credentials, and put this terminal to the side or minimize it, but leave it open until you are done working with Jupyter for this session.
 
-`[user@laptop:~]$ ssh -N -L 8888:<nodename>:8888 username@kestrel.hpc.nrel.gov`
+`[user@laptop:~]$ ssh -N -L 8888:<nodename>:8888 username@kestrel.hpc.nlr.gov`
 
 ### Open a Web Browser
 

--- a/docs/Documentation/Development/Languages/Python/KestrelParallelPythonJupyter/pyEnvsAndLaunchingJobs.md
+++ b/docs/Documentation/Development/Languages/Python/KestrelParallelPythonJupyter/pyEnvsAndLaunchingJobs.md
@@ -16,7 +16,7 @@ For a general introduction to using Jupyter notebooks on Kestrel, please refer t
 
 Login to Kestrel
 ```
-$ ssh -X <username>@kestrel-gpu.hpc.nrel.gov
+$ ssh -X <username>@kestrel-gpu.hpc.nlr.gov
 ```
 
 Navigate to your /projects directory
@@ -167,7 +167,7 @@ The text in the red box shows an example of the output parameter `<nodename>` an
 
 2. Local terminal: Establish a SSH tunnel
     ```
-    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel-gpu.hpc.nrel.gov
+    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel-gpu.hpc.nlr.gov
     ```
 
 3. Web browser
@@ -197,7 +197,7 @@ The text in the red box shows an example of the output parameter `<nodename>` an
 
 2. Local terminal: Establish a SSH tunnel
     ```
-    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel.hpc.nrel.gov
+    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel.hpc.nlr.gov
     ```
 
 3. Web browser
@@ -221,7 +221,7 @@ The text in the red box shows an example of the output parameter `<nodename>` an
 
 2. Local terminal: Establish a SSH tunnel
     ```
-    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel.hpc.nrel.gov
+    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel.hpc.nlr.gov
     ```
 
 3. Web browser
@@ -245,7 +245,7 @@ The text in the red box shows an example of the output parameter `<nodename>` an
 
 2. Local terminal: Establish a SSH tunnel
     ```
-    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel-gpu.hpc.nrel.gov
+    $ ssh -N -L 8888:<nodename>:8888 <username>@kestrel-gpu.hpc.nlr.gov
     ```
 
 3. Web browser

--- a/docs/Documentation/Development/Performance_Tools/Linaro-Forge/map.md
+++ b/docs/Documentation/Development/Performance_Tools/Linaro-Forge/map.md
@@ -20,7 +20,7 @@ Download the remote client from the [Linaroforge Website](https://www.linaroforg
 Once you have the client installed, you will need to configure it to connect to the host:
 
 1.	Open the Linaro Forge Client application
-2.	Select the configure option in the "Remote Launch" dropdown menu, click "Add" and set the hostname to "USER@HOST.hpc.nrel.gov" where USER is your username and HOST is the host you are trying to connect to. We recommend using DAV nodes if available on your system.
+2.	Select the configure option in the "Remote Launch" dropdown menu, click "Add" and set the hostname to "USER@HOST.hpc.nlr.gov" where USER is your username and HOST is the host you are trying to connect to. We recommend using DAV nodes if available on your system.
 3.	In the Remote Installation Directory field, set the path to the Linaro installation on your host. This can be found by running the command: 
 
 
@@ -39,7 +39,7 @@ Once you have the client installed, you will need to configure it to connect to 
 4.	Hit "Test Remote Launch" to test the configuration. 
 
 Once the remote client is correctly set up, start a terminal and connect to the desired HPC system.
-`$ ssh USER@$HOST.hpc.nrel.gov` 
+`$ ssh USER@$HOST.hpc.nlr.gov` 
 
 Continue to the [profiling section](map.md#profiling-a-program)
 

--- a/docs/Documentation/Development/VSCode/index.md
+++ b/docs/Documentation/Development/VSCode/index.md
@@ -10,7 +10,7 @@ Press "F1" to open the command bar, and type or search for `Remote-SSH: Connect 
 
 You may then enter your HPC username and the address of an HPC system to connect to. 
 
-* To connect to Kestrel from the NLR VPN, enter `username@kestrel.hpc.nrel.gov`, replacing "username" with your HPC user name.
+* To connect to Kestrel from the NLR VPN, enter `username@kestrel.hpc.nlr.gov`, replacing "username" with your HPC user name.
 
 * To connect to Kestrel as an external collaborator, enter `username@kestrel.nlr.gov`, replacing "username" with your HPC user name.
 
@@ -23,7 +23,7 @@ Enter your HPC password (or password and OTP code if external) and you will be c
     Some people who use Windows 10/11 computers to ssh to Kestrel via Visual Studio Code's SSH extension might receive an error message about a "Corrupted MAC on input" or "message authentication code incorrect." To workaround this issue, you will need to create an ssh config file on your local computer, `~/.ssh/config`, with a host entry for Kestrel that specifies a new message authentication code:
     ```
     Host kestrel
-        HostName kestrel.hpc.nrel.gov
+        HostName kestrel.hpc.nlr.gov
         MACs hmac-sha2-512
     ```
     This [Visual Studio Blog post](https://code.visualstudio.com/blogs/2019/10/03/remote-ssh-tips-and-tricks) has further instructions on how to create the ssh configuration file for Windows and VS Code.
@@ -48,9 +48,9 @@ We recommend choosing a strong passphrase and storing it in a password manager. 
     Do **not** replace the key pair in your Kestrel home directory. These keys are generated when you log into the cluster, and are used by Slurm jobs to communicate between nodes. There is a corresponding public key entry in your cluster home directory ~/.ssh/authorized_keys that must also be left in place.
 
 !!! note "Reminder About Passwords"
-    Using an SSH key with an SSH agent can remove the need to use a password to SSH to Kestrel. However, not all HPC services (including [Lex](https://hpcprojects.nrel.gov)) use SSH keys. **An SSH key does NOT replace your HPC account password**. You **must** maintain a regular HPC account password in accordance with our [Appropriate Use Policy](https://www.nlr.gov/hpc/appropriate-use-policy.html) and [User Account Password Guidelines](https://www.nlr.gov/hpc/user-account-passwords.html). Ignoring password expiration date notices will lead to automatic account lockouts, and you will need to contact [HPC Support](/Documentation/help) to restore your account.
+    Using an SSH key with an SSH agent can remove the need to use a password to SSH to Kestrel. However, not all HPC services (including [Lex](https://hpcprojects.nlr.gov)) use SSH keys. **An SSH key does NOT replace your HPC account password**. You **must** maintain a regular HPC account password in accordance with our [Appropriate Use Policy](https://www.nlr.gov/hpc/appropriate-use-policy.html) and [User Account Password Guidelines](https://www.nlr.gov/hpc/user-account-passwords.html). Ignoring password expiration date notices will lead to automatic account lockouts, and you will need to contact [HPC Support](/Documentation/help) to restore your account.
 
-Once you have a key pair on your local computer, use the `ssh-copy-id <username>@kestrel.hpc.nrel.gov` command to copy the public portion to Kestrel. This will add your public key to the ~/.ssh/authorized_keys file in your Kestrel home directory. Alternatively, you may manually add the contents of your PUBLIC key file (for example, the contents of ~/.ssh/id_ed25519.pub or ~/.ssh/id_rsa.pub) onto the end of this file. **Do not delete the existing entries in these files on Kestrel.**
+Once you have a key pair on your local computer, use the `ssh-copy-id <username>@kestrel.hpc.nlr.gov` command to copy the public portion to Kestrel. This will add your public key to the ~/.ssh/authorized_keys file in your Kestrel home directory. Alternatively, you may manually add the contents of your PUBLIC key file (for example, the contents of ~/.ssh/id_ed25519.pub or ~/.ssh/id_rsa.pub) onto the end of this file. **Do not delete the existing entries in these files on Kestrel.**
 
 ### Editing the VS Code SSH Config File
 
@@ -60,7 +60,7 @@ Use the remote-ssh command to edit your VS Code ssh config file (~/.ssh/config).
 
 ```
 Host x????c*
-    ProxyJump <username>@kestrel.hpc.nrel.gov
+    ProxyJump <username>@kestrel.hpc.nlr.gov
 ```
 
 This create a "wildcard" entry that should match Kestrel compute node names. Any time an ssh command is issued on your computer that matches the wildcard, the ssh connection will "jump" through a Kestrel login node and directly to the compute node.

--- a/docs/Documentation/Environment/shell.md
+++ b/docs/Documentation/Environment/shell.md
@@ -154,7 +154,7 @@ export LD_LIBRARY_PATH=/projects/mystuff/lib:$LD_LIBRARY_PATH
 If you have a commercial application that requires a license server you may need to set a variable to point to it.  For example:
 
 ```
-export LSERVER=license-1.hpc.nrel.gov:4691
+export LSERVER=license-1.hpc.nlr.gov:4691
 ```
 
 

--- a/docs/Documentation/Machine_Learning/TensorBoard/index.md
+++ b/docs/Documentation/Machine_Learning/TensorBoard/index.md
@@ -57,6 +57,6 @@ TensorBoard 2.5.0 at http://localhost:6006/ (Press CTRL+C to quit)
 ```
 Open a new Terminal tab and create a tunnel:
 ```
-ssh -NfL 6006:localhost:6006 $USER@el1.hpc.nrel.gov
+ssh -NfL 6006:localhost:6006 $USER@el1.hpc.nlr.gov
 ```
 Finally, open the above localhost url (`http://localhost:6006/`) in a browser, where all the aforementioned plots will be shown.

--- a/docs/Documentation/Machine_Learning/index.md
+++ b/docs/Documentation/Machine_Learning/index.md
@@ -212,7 +212,7 @@ Regardless of architecture, installing an accelerated version PyTorch on Gila is
 ??? example "Creating an arm-based PyTorch environment for Grace Hopper nodes on Gila"
     ```
     # Connect to the arm login node
-    ssh gila-arm.hpc.nrel.gov
+    ssh gila-arm.hpc.nlr.gov
     
     # Request partial Grace Hopper node for 15 minutes to create arm-based environment
     # Replace <allocation handle> accordingly

--- a/docs/Documentation/Managing_Data/Transferring_Files/FileZilla.md
+++ b/docs/Documentation/Managing_Data/Transferring_Files/FileZilla.md
@@ -14,7 +14,7 @@ parent: Transferring Data
 
 ### Connecting to a Host
 
-- Decide which host you wish to connect to such as, kestrel.hpc.nrel.gov
+- Decide which host you wish to connect to such as, kestrel.hpc.nlr.gov
 - Enter your username in the Username field.
 - Enter your password or Password+OTP Token in the Password field.
 - Use 22 as the Port.

--- a/docs/Documentation/Resource_Management_System/index.md
+++ b/docs/Documentation/Resource_Management_System/index.md
@@ -4,7 +4,7 @@
 
 ## Access
 
-An [NLR HPC account](https://www.nlr.gov/hpc/user-accounts.html) is required to access Lex. To log in to Lex, open a web browser to [https://hpcprojects.nrel.gov](https://hpcprojects.nrel.gov/login/?next=/). Log in with your NLR HPC username and password. An OTP token is not required to authenticate. 
+An [NLR HPC account](https://www.nlr.gov/hpc/user-accounts.html) is required to access Lex. To log in to Lex, open a web browser to [https://hpcprojects.nlr.gov](https://hpcprojects.nlr.gov/login/?next=/). Log in with your NLR HPC username and password. An OTP token is not required to authenticate. 
 
 ## Requesting an Allocation
 

--- a/docs/Documentation/Slurm/interactive_jobs.md
+++ b/docs/Documentation/Slurm/interactive_jobs.md
@@ -86,7 +86,7 @@ The above salloc command will log you into one of the two nodes automatically. Y
 If your single-node job needs a GUI that uses X-windows:
 
 ```
-$ ssh -Y kestrel.hpc.nrel.gov
+$ ssh -Y kestrel.hpc.nlr.gov
 ...
 $ salloc --time=20 --account=<handle> --nodes=1 --x11
 ```
@@ -102,7 +102,7 @@ $ salloc --time=20 --account=<handle> --nodes=2
 Then from your local workstation:
 
 ```
-$ ssh -Y kestrel.hpc.nrel.gov
+$ ssh -Y kestrel.hpc.nlr.gov
 ...
 [hpc_user@kl1 ~]$ ssh -Y x1008c7s6b1n0  #(from login node to reserved compute node)
 ...
@@ -110,7 +110,7 @@ $ ssh -Y kestrel.hpc.nrel.gov
 [hpc_user@x1008c7s6b1n0 ~]$ xterm  #(or another X11 GUI application)
 ```
 
-From a Kestrel-DAV FastX remote desktop session, you can omit the `ssh -Y kestrel.hpc.nrel.gov` above since your terminal in FastX will already be connected to a DAV (kd#) login node. 
+From a Kestrel-DAV FastX remote desktop session, you can omit the `ssh -Y kestrel.hpc.nlr.gov` above since your terminal in FastX will already be connected to a DAV (kd#) login node. 
 
 
 ## Requesting Interactive GPU Nodes

--- a/docs/Documentation/Systems/Gila/filesystem.md
+++ b/docs/Documentation/Systems/Gila/filesystem.md
@@ -2,7 +2,7 @@
 
 ## Home Directories: /home
 
-`/home` directories are mounted as `/home/<username>`. To check your usage in your /home directory, visit the [Gila Filesystem Dashboard](https://influx.hpc.nrel.gov/d/ch4vndd/ceph-filesystem-quotas?folderUid=fexgrdi5pt91ca&orgId=1&from=now-1h&to=now&timezone=browser&tab=queries). You can also check your home directory usage and quota by running the following commands: 
+`/home` directories are mounted as `/home/<username>`. To check your usage in your /home directory, visit the [Gila Filesystem Dashboard](https://influx.hpc.nlr.gov/d/ch4vndd/ceph-filesystem-quotas?folderUid=fexgrdi5pt91ca&orgId=1&from=now-1h&to=now&timezone=browser&tab=queries). You can also check your home directory usage and quota by running the following commands: 
 
 ```
 # Check usage
@@ -15,7 +15,7 @@ If you need a quota increase in your home directory, please contact [HPC-Help@nl
 
 ## Project Storage: /projects
 
-Each active project is granted a subdirectory under `/projects/<projectname>`. There are currently no quotas on `/projects` directories. Please monitor your space usage at the [Gila Filesystem Dashboard](https://influx.hpc.nrel.gov/d/ch4vndd/ceph-filesystem-quotas?folderUid=fexgrdi5pt91ca&orgId=1&from=now-1h&to=now&timezone=browser&tab=queries). 
+Each active project is granted a subdirectory under `/projects/<projectname>`. There are currently no quotas on `/projects` directories. Please monitor your space usage at the [Gila Filesystem Dashboard](https://influx.hpc.nlr.gov/d/ch4vndd/ceph-filesystem-quotas?folderUid=fexgrdi5pt91ca&orgId=1&from=now-1h&to=now&timezone=browser&tab=queries). 
 
 Note that there is currently no `/projects/aurorahpc` directory. Data can be kept in your `/home` directory. 
 

--- a/docs/Documentation/Systems/Gila/index.md
+++ b/docs/Documentation/Systems/Gila/index.md
@@ -13,11 +13,11 @@ The aurorahpc allocation does have limited resources allowed per job. These limi
 #### For NLR Employees:
 To access Gila, log in to the NLR network and connect via ssh to:
 
-    gila.hpc.nrel.gov
+    gila.hpc.nlr.gov
 
 To use the Grace Hopper nodes, connect via ssh to:
 
-    gila-arm.hpc.nrel.gov
+    gila-arm.hpc.nlr.gov
 
 #### For External Collaborators:
 There are no external-facing login nodes for Gila. There are two options to connect:

--- a/docs/Documentation/Systems/Gila/modules.md
+++ b/docs/Documentation/Systems/Gila/modules.md
@@ -21,8 +21,8 @@ The two hardware stacks are almost identical in terms of available modules. Howe
 
 To ensure proper module compatibility, connect to the login node corresponding to your target compute architecture:
 
-- **x86 architecture**: Use `gila.hpc.nrel.gov` 
-- **ARM architecture**: Use `gila-arm.hpc.nrel.gov` (Grace Hopper nodes)
+- **x86 architecture**: Use `gila.hpc.nlr.gov` 
+- **ARM architecture**: Use `gila-arm.hpc.nlr.gov` (Grace Hopper nodes)
 
 
 !!! warning

--- a/docs/Documentation/Systems/Gila/running.md
+++ b/docs/Documentation/Systems/Gila/running.md
@@ -21,7 +21,7 @@ There are four types of GPU nodes on Gila, including the Grace Hopper nodes desc
 
 ### Grace Hopper Nodes
 
-Gila has 5 NVIDIA Grace Hopper nodes. To use the Grace Hopper nodes, submit your jobs to the `gh` partition from the `gila-arm.hpc.nrel.gov` login node. Each Grace Hopper node has a 72 core NVIDIA Grace CPU and an NVIDIA GH200 GPU, with 96GB of VRAM and 470GB of RAM. They have one socket and NUMA node. 
+Gila has 5 NVIDIA Grace Hopper nodes. To use the Grace Hopper nodes, submit your jobs to the `gh` partition from the `gila-arm.hpc.nlr.gov` login node. Each Grace Hopper node has a 72 core NVIDIA Grace CPU and an NVIDIA GH200 GPU, with 96GB of VRAM and 470GB of RAM. They have one socket and NUMA node. 
 
 Please note - the __NVIDIA Grace CPUs__ run on a different processing architecture (ARM64) than both the __Intel Xeon Icelake CPUs__ (x86-64) and the __AMD EPYC Milan__ (x86-64). Any application that is manually compiled by a user and intended to be used on the Grace Hopper nodes __MUST__ be compiled on the Grace Hopper nodes themselves.
 

--- a/docs/Documentation/Systems/Kestrel/Environments/gpubuildandrun.md
+++ b/docs/Documentation/Systems/Kestrel/Environments/gpubuildandrun.md
@@ -12,7 +12,7 @@ tar -xzf /nopt/nrel/apps/examples/gpu/h100.tgz
 Or you can use git to do a download:
 
 ```bash
-git clone $USER@kestrel.hpc.nrel.gov:/nopt/nrel/apps/examples/gpu/0824 h100
+git clone $USER@kestrel.hpc.nlr.gov:/nopt/nrel/apps/examples/gpu/0824 h100
 ```
 
 After getting the source you can run all of the examples:

--- a/docs/Documentation/Systems/Kestrel/Environments/tutorial.md
+++ b/docs/Documentation/Systems/Kestrel/Environments/tutorial.md
@@ -33,7 +33,7 @@ Kestrel comes pre-packaged with several "programming environments." You can see 
 We're going to walk through building and running an MPI benchmarking code called IMB. This is a simple code that only requires a compiler and an MPI as dependencies (no scientific libraries, etc. are needed).
 
 First, log onto Kestrel with
-`ssh [your username]@kestrel.hpc.nrel.gov`
+`ssh [your username]@kestrel.hpc.nlr.gov`
 
 Let's grab an interactive node session:
 

--- a/docs/Documentation/Systems/Kestrel/index.md
+++ b/docs/Documentation/Systems/Kestrel/index.md
@@ -23,29 +23,29 @@ Kestrel has two types of login nodes, CPU and GPU, which share the same architec
 
 Users on an NLR device may connect via ssh to Kestrel from the NLR network using:
 
-* kestrel.hpc.nrel.gov (CPU)
-* kestrel-gpu.hpc.nrel.gov (GPU)
+* kestrel.hpc.nlr.gov (CPU)
+* kestrel-gpu.hpc.nlr.gov (GPU)
 
  This will connect to one of the three login nodes using a round-robin load balancing approach. Users also have the option of connecting directly to an individual login node using one of the following names: 
 
-* kl1.hpc.nrel.gov (CPU)
-* kl2.hpc.nrel.gov (CPU)
-* kl3.hpc.nrel.gov (CPU)
-* kl5.hpc.nrel.gov (GPU)
-* kl6.hpc.nrel.gov (GPU)
+* kl1.hpc.nlr.gov (CPU)
+* kl2.hpc.nlr.gov (CPU)
+* kl3.hpc.nlr.gov (CPU)
+* kl5.hpc.nlr.gov (GPU)
+* kl6.hpc.nlr.gov (GPU)
 
 #### For External Collaborators:
 If you are an external HPC user, you will need a [One-Time Password Multifactor token (OTP)](https://www.nlr.gov/hpc/multifactor-tokens.html) for two-factor authentication.
 
 For command line access, you may login directly to **kestrel.nlr.gov**.  Alternatively, you can connect to the [SSH gateway host](https://www.nlr.gov/hpc/ssh-gateway-connection.html) or the [HPC VPN](https://www.nlr.gov/hpc/vpn-connection.html).
 
-To access the GPU login nodes, first connect with one of the methods described above, and then ssh to **kestrel-gpu.hpc.nrel.gov**. 
+To access the GPU login nodes, first connect with one of the methods described above, and then ssh to **kestrel-gpu.hpc.nlr.gov**. 
 
 !!! warning "Windows SSH "Corrupted MAC on input" Error"
     When attempting to SSH, some Windows users experience an error message stating "Corrupted MAC on input" or "message authentication code incorrect." To solve the error, run the ssh command with the flag `-m hmac-sha2-512`. Example below:
 
     ```
-    ssh -m hmac-sha2-512 username@kestrel.hpc.nrel.gov
+    ssh -m hmac-sha2-512 username@kestrel.hpc.nlr.gov
     ```
 
     See the [Workaround blog post](../../../blog/2022-12-19-windows_ssh.md) for further details and information.
@@ -59,7 +59,7 @@ There are eight DAV nodes available on Kestrel, which are nodes intended for HPC
 
 [FastX](../../Viz_Analytics/virtualgl_fastx.md) is available for HPC users to use graphical applications on the DAV nodes.
 
-To connect to a DAV node using the load balancing algorithim, NLR employees can connect to **kestrel-dav.hpc.nrel.gov**. To connect from outside the NLR network, use **kestrel-dav.nlr.gov**. 
+To connect to a DAV node using the load balancing algorithim, NLR employees can connect to **kestrel-dav.hpc.nlr.gov**. To connect from outside the NLR network, use **kestrel-dav.nlr.gov**. 
 
 
 ## Get Help With Kestrel

--- a/docs/Documentation/Systems/Swift/index.md
+++ b/docs/Documentation/Systems/Swift/index.md
@@ -18,8 +18,8 @@ Access to Swift requires an NLR HPC account and permission to join an existing a
 
 #### Login Nodes:
 ```
-swift.hpc.nrel.gov
-swift-login-1.hpc.nrel.gov
+swift.hpc.nlr.gov
+swift-login-1.hpc.nlr.gov
 ```
 #### For NLR Employees:
 Swift can be reached from the NLR VPN via ssh to the login nodes as above.

--- a/docs/Documentation/Systems/Swift/running.md
+++ b/docs/Documentation/Systems/Swift/running.md
@@ -12,11 +12,11 @@ Please see the [Modules](./modules.md) page for information about setting up you
 ## Login nodes
 
 ```
-swift.hpc.nrel.gov
-swift-login-1.hpc.nrel.gov
+swift.hpc.nlr.gov
+swift-login-1.hpc.nlr.gov
 ```
 
-`swift.hpc.nrel.gov` is a round-robin alias that will connect you to any available login node.
+`swift.hpc.nlr.gov` is a round-robin alias that will connect you to any available login node.
 
 ## SSH Keys
 
@@ -117,7 +117,7 @@ Usage is tracked on the basis of:
 
 ### AU Calculation Examples
 
-AU calculations are performed automatically between the Slurm scheduler and [Lex](https://hpcprojects.nrel.gov)(NLR's web-based allocation tracking/management software). The following calculations are approximations to help illustrate how your AU will be consumed based on your job resource requests and are approximations only:
+AU calculations are performed automatically between the Slurm scheduler and [Lex](https://hpcprojects.nlr.gov)(NLR's web-based allocation tracking/management software). The following calculations are approximations to help illustrate how your AU will be consumed based on your job resource requests and are approximations only:
 
 A request of 1 GPU, up to 24 CPU cores, and up to 256GB RAM will be charged at 12.5 AU/hr:
 
@@ -278,7 +278,7 @@ export OMP_NUM_THREADS=2
 srun  -n 4 ./fhostone -F
 srun  -n 4 ./phostone -F
 
-MPI Version:Open MPI v4.1.1, package: Open MPI nrmc2l@swift-login-1.swift.hpc.nrel.gov Distribution, ident: 4.1.1, repo rev: v4.1.1, Apr 24, 2021
+MPI Version:Open MPI v4.1.1, package: Open MPI nrmc2l@swift-login-1.swift.hpc.nlr.gov Distribution, ident: 4.1.1, repo rev: v4.1.1, Apr 24, 2021
 task    thread             node name  first task    # on node  core
 0002      0000                 c1-31        0002         0000   018
 0000      0000                 c1-30        0000         0000   072
@@ -292,7 +292,7 @@ task    thread             node name  first task    # on node  core
 0001      0001                 c1-30        0000         0001  0103
 0003      0000                 c1-31        0002         0001  0062
 0003      0001                 c1-31        0002         0001  0103
-MPI VERSION Open MPI v4.1.1, package: Open MPI nrmc2l@swift-login-1.swift.hpc.nrel.gov Distribution, ident: 4.1.1, repo rev: v4.1.1, Apr 24, 2021
+MPI VERSION Open MPI v4.1.1, package: Open MPI nrmc2l@swift-login-1.swift.hpc.nlr.gov Distribution, ident: 4.1.1, repo rev: v4.1.1, Apr 24, 2021
 task    thread             node name  first task    # on node  core
 0000      0000                 c1-30        0000         0000  0072
 0000      0001                 c1-30        0000         0000  0020

--- a/docs/Documentation/Systems/index.md
+++ b/docs/Documentation/Systems/index.md
@@ -13,7 +13,7 @@ NLR operates three on-premises systems for computational work.
 | Name        | Kestrel |  Swift        | Gila     | 
 | :---------- | :------ |  :----------- | :------------- |
 | OS          | RedHat Enterprise Linux |  Rocky Linux    | Rocky Linux       |
-| Login       | kestrel.hpc.nrel.gov |  swift.hpc.nrel.gov | gila.hpc.nrel.gov |
+| Login       | kestrel.hpc.nlr.gov |  swift.hpc.nlr.gov | gila.hpc.nlr.gov |
 | CPU         | Dual socket Intel Xeon Sapphire Rapids |  Dual AMD EPYC 7532 Rome CPU | Dual AMD EPYC Milan |
 | Cores per CPU Node | 104 cores |  128 cores | Varies by partition | 
 | Interconnect | HPE Slingshot 11 | InfiniBand HDR| 25GbE |

--- a/docs/Documentation/Viz_Analytics/paraview.md
+++ b/docs/Documentation/Viz_Analytics/paraview.md
@@ -89,7 +89,7 @@ In this model, the HPC does the I/O and computational work, then "serves" the re
     Open a new local terminal window:
     
     ```bash
-    ssh -L 11111:<node_name>:11111 <username>@kestrel.hpc.nrel.gov
+    ssh -L 11111:<node_name>:11111 <username>@kestrel.hpc.nlr.gov
     ```
     
     where `<node_name>` is the node name you copied in Step 1 and `<username>` is your HPC username.
@@ -142,7 +142,7 @@ How to use ParaView in batch mode to generate single frames and animations on Ke
 1.  Begin by connecting to a Kestrel login node:
 
     ```bash
-    ssh <username>@kestrel.hpc.nrel.gov
+    ssh <username>@kestrel.hpc.nlr.gov
     ```
 
 2.  Request an interactive compute session for 60 minutes:

--- a/docs/Documentation/Viz_Analytics/virtualgl_fastx.md
+++ b/docs/Documentation/Viz_Analytics/virtualgl_fastx.md
@@ -8,7 +8,7 @@ In addition to standard ssh-only login nodes, Kestrel is also equipped with seve
 !!! Note About Usage
     DAV FastX nodes are a limited resource and not intended as a general-purpose remote desktop. We ask that you please restrict your usage to only HPC allocation-related work and/or visualization software that requires an HPC system.
 
-There are seven internal DAV nodes on Kestrel available only to NLR users on the NLR VPN, on campus, or via the [HPC VPN](https://www.nlr.gov/hpc/vpn-connection.html) that are accessible via round-robin at **kestrel-dav.hpc.nrel.gov**. The individual nodes are named kd1 through kd7.hpc.nrel.gov.
+There are seven internal DAV nodes on Kestrel available only to NLR users on the NLR VPN, on campus, or via the [HPC VPN](https://www.nlr.gov/hpc/vpn-connection.html) that are accessible via round-robin at **kestrel-dav.hpc.nlr.gov**. The individual nodes are named kd1 through kd7.hpc.nlr.gov.
 
 There is also one node that is ONLY accessible by external (non-NLR) users available at **kestrel-dav.nlr.gov**. This address will connect to the node kd8, and requires both password and OTP for login. 
 
@@ -32,7 +32,7 @@ NLR users may use the web browser or the FastX desktop client. External users mu
 ??? abstract "NLR On-Site and VPN Users" 
     ### Using a Web Browser
 
-    Launch a web browser on your local machine and connect to [https://kestrel-dav.hpc.nrel.gov](https://kestrel-dav.hpc.nrel.gov). After logging in with your HPC username/password you will be able to launch a FastX session by choosing a desktop environment of your choice. Either [GNOME](https://www.gnome.org/) or [XFCE](https://www.xfce.org/) are available for use.
+    Launch a web browser on your local machine and connect to [https://kestrel-dav.hpc.nlr.gov](https://kestrel-dav.hpc.nlr.gov). After logging in with your HPC username/password you will be able to launch a FastX session by choosing a desktop environment of your choice. Either [GNOME](https://www.gnome.org/) or [XFCE](https://www.xfce.org/) are available for use.
 
 
     ### Using the Desktop Client 
@@ -54,7 +54,7 @@ NLR users may use the web browser or the FastX desktop client. External users mu
 
     Give your profile a name and enter the settings...
 
-    Address/URL: *kestrel-dav.hpc.nrel.gov*
+    Address/URL: *kestrel-dav.hpc.nlr.gov*
 
     OR you may use the address of an individual kd or ed node if you would like to resume a previous session.
 
@@ -179,7 +179,7 @@ nodes that you are not using, or your sessions may be terminated by system admin
 active users. 
 
 ## Reattaching FastX Sessions
-Connections to the DAV nodes via kestrel-dav.hpc.nrel.gov will connect you to a random node. To resume a session that you have suspended, take note of the node your session is running on (kd1, kd2, kd3, kd4, kd5, kd6, or kd7) before you close the FastX client or browser window, and you may directly access that node when you are ready to reconnect at e.g. `kd#.hpc.nrel.gov` in the FastX client or through your web browser at `https://kd#.hpc.nrel.gov`. 
+Connections to the DAV nodes via kestrel-dav.hpc.nlr.gov will connect you to a random node. To resume a session that you have suspended, take note of the node your session is running on (kd1, kd2, kd3, kd4, kd5, kd6, or kd7) before you close the FastX client or browser window, and you may directly access that node when you are ready to reconnect at e.g. `kd#.hpc.nlr.gov` in the FastX client or through your web browser at `https://kd#.hpc.nlr.gov`. 
 
 ## Compute Intensive GUI Applications
 

--- a/docs/Documentation/Viz_Analytics/visit.md
+++ b/docs/Documentation/Viz_Analytics/visit.md
@@ -34,7 +34,7 @@ VisIt features a robust remote visualization capability.  To enable remote visua
 ![Alt text](../../assets/images/VisIT/kestrel-software-visit-step7.png)
 6. To connect to VisIt, go to File → Open file
 ![Alt text](../../assets/images/VisIT/kestrel-8.png)
-7. In the Host option, click on the drop down menu and choose the host kestrel.hpc.nrel.gov
+7. In the Host option, click on the drop down menu and choose the host kestrel.hpc.nlr.gov
 ![Alt text](../../assets/images/VisIT/kestrel-9.png)
 8. It will display a window with an option to change the username, if the username is not correct, then click on change username. *This is your HPC username*
 9. Type your HPC username and click Confirm username.

--- a/docs/Documentation/getting_started.md
+++ b/docs/Documentation/getting_started.md
@@ -45,13 +45,13 @@ Below we've collected answers for many of the most frequently asked questions.
     lasting 60 seconds) token to use along with your account password. Tokens are generated
     using the current time stamp and a secure hashing algorithm.  **Note that you only need an 
     OTP to access systems outside the NLR firewall**, namely if you are an external collaborator. 
-    NLR employees can be on-site or use a VPN to access HPC systems via the *.hpc.nrel.gov domain.
+    NLR employees can be on-site or use a VPN to access HPC systems via the *.hpc.nlr.gov domain.
 
 ??? note "What is a virtual private network (VPN)?"
 
     VPNs simulate being within a firewall (which is an aggressive filter on inbound network
     traffic) by encapsulating your traffic in a secure channel that funnels through the
-    NLR network. While connected to a VPN, internal network domains such as *.hpc.nrel.gov
+    NLR network. While connected to a VPN, internal network domains such as *.hpc.nlr.gov
     can be accessed without secondary authentication (as the VPN itself counts as a secondary
     authentication). NLR employees may use the NLR VPN while external collaborators
     may use the NLR HPC VPN using their OTP token. This provides the convenience of not

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ A collection of various resources, examples, and executables for the general NLR
 [Documentation](Documentation/index.md){ .md-button }
 
 ## Contributing 
-These docs are driven by the NLR HPC community. They are currently under active development. If you would like to [contribute](https://github.com/NREL/HPC/blob/master/CONTRIBUTING.md) or recommend a topic to be covered please open an issue or pull request in the repository. 
+These docs are driven by the NLR HPC community. They are currently under active development. If you would like to [contribute](https://github.com/NatLabRockies/HPC/blob/master/CONTRIBUTING.md) or recommend a topic to be covered please open an issue or pull request in the repository. 
 
-[Docs repository](https://github.com/NREL/hpc){ .md-button } 
+[Docs repository](https://github.com/NatLabRockies/HPC){ .md-button } 
 
 ## Workshops
 The HPC community also hosts workshops covering various topics. Check the training calendar below as well as the [Computational Sciences Tutorials team](https://teams.microsoft.com/l/team/19%3a6nLmPDt9QHQMEuLHVBaxfsitEZSGH6oXT6lyVauMvXY1%40thread.tacv2/conversations?groupId=22ad3c7b-a45a-4880-b8b4-b70b989f1344&tenantId=a0f29d7e-28cd-4f54-8442-7885aee7c080) to view all tutorials and workshops put on by the Computational Science Center. Join the team to receive notifications and seek out new or upcoming tutorials. For more information on joining this channel as a user external to NLR, see our [Help and Support page](./Documentation/help.md). For a list of slide desks and recordings of past trainings, visit the [HPC Tutorials Sharepoint page](https://nrel.sharepoint.com/sites/ComputationalSciencesTutorials/SitePages/Computational-Science-Tutorials-HPC.aspx?csf=1&web=1&e=Je7el3&ovuser=a0f29d7e-28cd-4f54-8442-7885aee7c080%2Chyandt%40nrel.gov&OR=Teams-HL&CT=1750864607370&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTA1MTgwMDIxOSJ9&CID=699daba1-5033-9000-49be-425a4c8a8eda&cidOR=SPO).


### PR DESCRIPTION
Updated links/hosts on most pages; Vermilion excluded as it is only accessible via search and is no longer in service.
I also did not update the old blog post about the Corrupt MAC issue. Let me know if I should.
harbor.nrel.gov and github.nrel.gov do not have working nlr equivalents yet, so I did not update those as well. 